### PR TITLE
Add HLSL version of grad4, initializer fix in random.hlsl

### DIFF
--- a/generative/random.hlsl
+++ b/generative/random.hlsl
@@ -27,7 +27,7 @@ float random(in float4 pos) {
 #define RANDOM_SCALE3 float3(.1031, .1030, .0973)
 #define FANDOM_SCALE4 float4(.1031, .1030, .0973, .1099)
 float2 random2(float p) {
-    float3 p3 = frac(float3(p) * RANDOM_SCALE3);
+    float3 p3 = frac(float3(p, p, p) * RANDOM_SCALE3);
     p3 += dot(p3, p3.yzx + 19.19);
     return frac((p3.xx+p3.yz)*p3.zy);
 }
@@ -45,7 +45,7 @@ float2 random2(float3 p3) {
 }
 
 float3 random3(float p) {
-    float3 p3 = frac(float3(p) * RANDOM_SCALE3);
+    float3 p3 = frac(float3(p, p, p) * RANDOM_SCALE3);
     p3 += dot(p3, p3.yzx+19.19);
     return frac((p3.xxy+p3.yzz)*p3.zyx); 
 }
@@ -64,7 +64,7 @@ float3 random3(in float3 p) {
 }
 
 float4 random4(float p) {
-    float4 p4 = frac(float4(p) * FANDOM_SCALE4);
+    float4 p4 = frac(float4(p, p, p, p) * FANDOM_SCALE4);
     p4 += dot(p4, p4.wzxy+19.19);
     return frac((p4.xxyz+p4.yzzw)*p4.zywx);   
 }

--- a/math/grad4.hlsl
+++ b/math/grad4.hlsl
@@ -1,0 +1,24 @@
+/*
+author: [Ian McEwan, Ashima Arts]
+description: grad4, used for snoise(float4 v)
+use: grad4(<float> j, <float4> ip)
+license: |
+  Copyright (C) 2011 Ashima Arts. All rights reserved.
+  Distributed under the MIT License. See LICENSE file.
+  https://github.com/ashima/webgl-noise
+*/
+#ifndef FNC_GRAD4
+#define FNC_GRAD4
+float4 grad4(float j, float4 ip) {
+    const float4 ones = float4(1.0, 1.0, 1.0, -1.0);
+    float4 p,s;
+
+    p.xyz = floor( frac (float3(j, j, j) * ip.xyz) * 7.0) * ip.z - 1.0;
+    p.w = 1.5 - dot(abs(p.xyz), ones.xyz);
+    // GLSL: s = float4(lessThan(p, float4(0.0)));
+    s = float4(1 - step(float4(0, 0, 0, 0), p));
+    p.xyz = p.xyz + (s.xyz * 2.0 - 1.0) * s.www;
+
+    return p;
+}
+#endif


### PR DESCRIPTION
`grad4.glsl` didn't have a parallel HLSL version, adding that.
Note: 
I had to make the following change, because HLSL doesn't have a `lessThan` function:
```
// 1 - step(y, x) is the same as (x < y)

// GLSL: s = float4(lessThan(p, float4(0.0)));
s = float4(1 - step(float4(0, 0, 0, 0), p));
```

Also making some changes to `random.hlsl`, which had some `float{n}` constructors with a single argument.