### PR TITLE
Some HLSL type fixes in code + comments

### DIFF
--- a/color/space/YPbPr2rgb.hlsl
+++ b/color/space/YPbPr2rgb.hlsl
@@ -30,7 +30,7 @@ float3 YPbPr2rgb(in float3 rgb) {
     return mul(YPbPr2rgb_mat, rgb);
 }
 
-vec4 YPbPr2rgb(in vec4 rgb) {
-    return vec4(YPbPr2rgb(rgb.rgb),rgb.a);
+float4 YPbPr2rgb(in float4 rgb) {
+    return float4(YPbPr2rgb(rgb.rgb),rgb.a);
 }
 #endif

--- a/color/space/cmyk2rgb.hlsl
+++ b/color/space/cmyk2rgb.hlsl
@@ -13,6 +13,6 @@ license: |
 #define FNC_CMYK2RGB
 float3 cmyk2rgb(float4 cmyk) {
     float invK = 1.0 - cmyk.w;
-    return saturate(1.0-min(float3(1.0), cmyk.xyz * invK + cmyk.w));
+    return saturate(1.0-min(float3(1.0, 1.0, 1.0), cmyk.xyz * invK + cmyk.w));
 }
 #endif

--- a/color/space/rgb2cmyk.hlsl
+++ b/color/space/rgb2cmyk.hlsl
@@ -1,4 +1,4 @@
-#include "../../math/min.glsl"
+#include "../../math/min.hlsl"
 
 /*
 author: Patricio Gonzalez Vivo

--- a/generative/noised.hlsl
+++ b/generative/noised.hlsl
@@ -3,7 +3,7 @@
 /*
 author: Inigo Quilez
 description: returns 2D/3D value noise in the first channel and in the rest the derivatives. For more details read this nice article http://www.iquilezles.org/www/articles/gradientnoise/gradientnoise.htm
-use: noised(<vec2|vec3> space)
+use: noised(<float2|float3> space)
 options:
   NOISED_QUINTIC_INTERPOLATION: Quintic interpolation on/off. Default is off.
 license: |

--- a/generative/snoise.hlsl
+++ b/generative/snoise.hlsl
@@ -6,7 +6,7 @@
 /*
 author: [Ian McEwan, Ashima Arts]
 description: Simplex Noise https://github.com/ashima/webgl-noise
-use: snoise(<vec2|vec3|vec4> pos)
+use: snoise(<float2|float3|float4> pos)
 license: |
   Copyright (C) 2011 Ashima Arts. All rights reserved.
   Copyright (C) 2011-2016 by Stefan Gustavson (Classic noise and others)

--- a/math/mod.hlsl
+++ b/math/mod.hlsl
@@ -1,7 +1,7 @@
 /*
 author: Patricio Gonzalez Vivo
 description: simple mod
-use: mod(<vec2|vec3|vec4> value, <vec2|vec3|vec4> modulus)
+use: mod(<float2|float3|float4> value, <float2|float3|float4> modulus)
 license: |
   Copyright (c) 2017 Patricio Gonzalez Vivo.
   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/math/permute.hlsl
+++ b/math/permute.hlsl
@@ -3,7 +3,7 @@
 /*
 author: [Ian McEwan, Ashima Arts]
 description: permute
-use: permute(<float|vec2|vec3|vec4> x)
+use: permute(<float|float2|float3|float4> x)
 license : |
   Copyright (C) 2011 Ashima Arts. All rights reserved.
   Distributed under the MIT License. See LICENSE file.

--- a/sdf/rhombSDF.hlsl
+++ b/sdf/rhombSDF.hlsl
@@ -2,7 +2,7 @@
 
 /*
 description: Returns a rhomb-shaped sdf
-use: rhombSDF(<vec2> st)
+use: rhombSDF(<float2> st)
 author: Patricio Gonzalez Vivo
 license: |
     Copyright (c) 2017 Patricio Gonzalez Vivo. All rights reserved.


### PR DESCRIPTION
There were some `vec{n}` references in HLSL files, correcting them.