### PR TITLE
Fix typo in hueShift.glsl/hlsl

### DIFF
--- a/color/hueShift.glsl
+++ b/color/hueShift.glsl
@@ -23,4 +23,4 @@ vec3 hueShift(in vec3 color, in float amount) {
 vec4 hueShift(in vec4 color, in float amount) {
     return vec4(hueShift(color.rgb, amount), color.a);
 }
-#endif`
+#endif

--- a/color/hueShift.hlsl
+++ b/color/hueShift.hlsl
@@ -23,4 +23,4 @@ float3 hueShift(in float3 color, in float amount) {
 float4 hueShift(in float4 color, in float amount) {
     return float4(hueShift(color.rgb, amount), color.a);
 }
-#endif`
+#endif


### PR DESCRIPTION
Small typo in `hueShift.glsl` and `hueShift.hlsl`
There's an extra``` at the end :)