### PR TITLE
Default SURFACE_POSITION to vec3(0.0)

### DIFF
--- a/lighting/light/point.glsl
+++ b/lighting/light/point.glsl
@@ -16,7 +16,7 @@ options:
 #include "falloff.glsl"
 
 #ifndef SURFACE_POSITION
-#define SURFACE_POSITION v_position
+#define SURFACE_POSITION vec3(0.0)
 #endif
 
 #ifndef LIGHT_POSITION


### PR DESCRIPTION
Same as before: if the PBR shader is included outside Viewer, this variable will be undefined. My understanding is that this mechanism allows to include in 'stock' configuration and override for custom use