### PR TITLE
feat: enhance sampleViewPosition

### DIFF
--- a/sample/viewPosition.glsl
+++ b/sample/viewPosition.glsl
@@ -18,6 +18,10 @@ options:
 
 #ifndef FNC_SAMPLEVIEWPOSITION
 #define FNC_SAMPLEVIEWPOSITION
+vec4 sampleViewPosition(const in float depth, const in vec2 st, const in float near, const in float far) {
+    float viewZ = depth2viewZ(depth, near, far);
+    return screen2viewPosition(st, depth, viewZ);
+}
 
 vec4 sampleViewPosition(sampler2D texDepth, const in vec2 st, const in float near, const in float far) {
     float depth = SAMPLER_FNC(texDepth, st).r;
@@ -26,7 +30,7 @@ vec4 sampleViewPosition(sampler2D texDepth, const in vec2 st, const in float nea
 }
 
 #if defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)
-float sampleViewPosition(sampler2D texDepth, const in vec2 st) {
+vec4 sampleViewPosition(sampler2D texDepth, const in vec2 st) {
     return sampleViewPosition( texDepth, st, CAMERA_NEAR_CLIP, CAMERA_FAR_CLIP); 
 }
 #endif

--- a/sample/viewPosition.hlsl
+++ b/sample/viewPosition.hlsl
@@ -17,6 +17,10 @@ options:
 
 #ifndef FNC_SAMPLEVIEWPOSITION
 #define FNC_SAMPLEVIEWPOSITION
+float4 sampleViewPosition(const in float depth, const in float2 st, const in float near, const in float far) {
+    float viewZ = depth2viewZ(depth, near, far);
+    return screen2viewPosition(st, depth, viewZ);
+}
 
 float4 sampleViewPosition(sampler2D texDepth, const in float2 st, const in float near, const in float far) {
     float depth = SAMPLER_FNC(texDepth, st).r;
@@ -25,7 +29,7 @@ float4 sampleViewPosition(sampler2D texDepth, const in float2 st, const in float
 }
 
 #if defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)
-float sampleViewPosition(sampler2D texDepth, const in float2 st) {
+float4 sampleViewPosition(sampler2D texDepth, const in float2 st) {
     return sampleViewPosition( texDepth, st, CAMERA_NEAR_CLIP, CAMERA_FAR_CLIP); 
 }
 #endif


### PR DESCRIPTION
In this PR, I support pass `depth` into `sampleViewPosition`.

On iOS 14-, the `WEBGL_depth_texture` extension has poor extension and we need to pack float to rgba8, and unpack it when we want to use it.

So it will be useful if we support passing `depth` directly.

One more thing, the old `sampleViewPosition` return type is wrong, and it has been fixed in this PR.