### PR TITLE
fix: linearizeDepth wrong

### DIFF
--- a/space/linearizeDepth.glsl
+++ b/space/linearizeDepth.glsl
@@ -17,7 +17,7 @@ license: |
 
 float linearizeDepth(float depth, float near, float far) {
     depth = 2.0 * depth - 1.0;
-    return (2.0 * near) / (far + near - depth * (far - near));
+    return (2.0 * near * far) / (far + near - depth * (far - near));
 }
 
 #if defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)

--- a/space/linearizeDepth.hlsl
+++ b/space/linearizeDepth.hlsl
@@ -17,7 +17,7 @@ license: |
 
 float linearizeDepth(float depth, float near, float far) {
     depth = 2.0 * depth - 1.0;
-    return (2.0 * near) / (far + near - depth * (far - near));
+    return (2.0 * near * far) / (far + near - depth * (far - near));
 }
 
 #if defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)


### PR DESCRIPTION
From https://learnopengl.com/Advanced-OpenGL/Depth-testing, the linearize depth formula is

```glsl
float ndc = depth * 2.0 - 1.0; 
float linearDepth = (2.0 * near * far) / (far + near - ndc * (far - near));
```

The code is missing `* far` part.