### PR TITLE
feat: adding triTile

### DIFF
--- a/space/triTile.glsl
+++ b/space/triTile.glsl
@@ -1,0 +1,20 @@
+/*
+original_author: Mathias Bredholt
+description: make some triangular tiles. XY provide coords inside of the tile. ZW provides tile coords
+use: <vec4> triTile(<vec2> st [, <float> scale])
+*/
+
+#ifndef FNC_TRITILE
+#define FNC_TRITILE
+vec4 triTile(vec2 st) {
+  st *= mat2(1., -1. / 1.7320508, 0., 2. / 1.7320508);
+  vec4 f = vec4(st, -st);
+  vec4 i = floor(f);
+  f = fract(f);
+  return dot(f.xy, f.xy) < dot(f.zw, f.zw)
+             ? vec4(f.xy, vec2(2., 1.) * i.xy)
+             : vec4(f.zw, -(vec2(2., 1.) * i.zw + 1.));
+}
+
+vec4 triTile(vec2 st, float scale) { return triTile(st * scale); }
+#endif


### PR DESCRIPTION
Adding a triTile function for creating triangle shaped tiles as suggested in #45 
- Loosely inspired by FabriceNeyret2 hexagonal tiling tuto https://www.shadertoy.com/view/4dKXR3
- The coords are skewed by the rotation matrix used to create the triangles. If might be nice if the output coords weren't skewed so the user can make non-skewed shapes inside the triangles. If anyone has a suggestion how to do that it would be most welcome! 
- I'm not familiar with the hlsl language and haven't got a setup to test it, can you make the translation @patriciogonzalezvivo?  