### PR TITLE
Fix aastep for WebGL2 and non-es OpenGL

### DIFF
--- a/draw/aastep.glsl
+++ b/draw/aastep.glsl
@@ -10,19 +10,20 @@ examples:
 
 #ifndef FNC_AASTEP
 #define FNC_AASTEP
+
 #ifdef GL_OES_standard_derivatives
-#extension GL_OES_standard_derivatives : enable
+    #extension GL_OES_standard_derivatives : enable
 #endif
 
 float aastep(float threshold, float value) {
-    #ifdef GL_OES_standard_derivatives
+#if !defined(GL_ES) || __VERSION__ >= 300 || defined(GL_OES_standard_derivatives)
     float afwidth = 0.7 * length(vec2(dFdx(value), dFdy(value)));
     return smoothstep(threshold-afwidth, threshold+afwidth, value);
-    #elif defined(AA_EDGE)
+#elif defined(AA_EDGE)
     float afwidth = AA_EDGE;
     return smoothstep(threshold-afwidth, threshold+afwidth, value);
-    #else 
+#else 
     return step(threshold, value);
-    #endif
+#endif
 }
 #endif


### PR DESCRIPTION
Hello,

Since `OES_standard_derivatives` extension is not present in OpenGL ES 3 (WebGL 2) and regular OpenGL it will wrongfully fallback to `step()`, so I tweaked the preprocessing checks to properly target the environment.

Sources:
https://registry.khronos.org/OpenGL-Refpages/gl4/html/fwidth.xhtml
https://registry.khronos.org/OpenGL-Refpages/es3.0/html/fwidth.xhtml
https://registry.khronos.org/OpenGL/extensions/OES/OES_standard_derivatives.txt
https://www.khronos.org/files/opengles_shading_language.pdf (page 12)