### PR TITLE
Fix bug on syntax error

### DIFF
--- a/lighting/pbrLittle.glsl
+++ b/lighting/pbrLittle.glsl
@@ -28,7 +28,7 @@ options:
 */
 
 #ifndef CAMERA_POSITION
-#define CAMERA_POSITION vec3(0.0, 0.0, -10.0);
+#define CAMERA_POSITION vec3(0.0, 0.0, -10.0)
 #endif
 
 #ifndef LIGHT_POSITION


### PR DESCRIPTION
Change this:
```
#define CAMERA_POSITION vec3(0.0, 0.0, -10.0);
```

To this:
```
#define CAMERA_POSITION vec3(0.0, 0.0, -10.0)
```

You will notice that typo syntax error is affected on this symbol `;` on `define` function