### PR TITLE
fix: "sample: Illegal use of reserved word" on WebGL shaders

### DIFF
--- a/sample.glsl
+++ b/sample.glsl
@@ -5,8 +5,3 @@
 #define SAMPLER_FNC(TEX, UV) texture2D(TEX, UV)
 #endif
 #endif
-
-#ifndef FNC_SAMPLE
-#define FNC_SAMPLE
-vec4 sample(sampler2D tex, vec2 uv) { return SAMPLER_FNC(tex, uv); }
-#endif

--- a/sample.hlsl
+++ b/sample.hlsl
@@ -2,7 +2,3 @@
 #define SAMPLER_FNC(TEX, UV) tex2D(TEX, UV)
 #endif
 
-#ifndef FNC_SAMPLE
-#define FNC_SAMPLE
-float4 sample(sampler2D tex, float2 uv) { return SAMPLER_FNC(tex, uv); }
-#endif


### PR DESCRIPTION
Fix #58 

This PR removes `sample()` definition (as I didn't find any usage reference of `FNC_SAMPLE` in the source code), but IDK what's the best choice for Lygia, I only wanted to highlight the issue.
