### PR TITLE
Fakecube fix & typos

### DIFF
--- a/lighting/fakeCube.glsl
+++ b/lighting/fakeCube.glsl
@@ -29,10 +29,10 @@ options:
 vec3 fakeCube(const in vec3 _normal, const in float _shininnes) {
 
     #if defined(FAKECUBE_SAMPLE_FNC)
-    vec3 colx = FAKECUBE_SAMPLE_FNC(d.yz).rgb;
-    vec3 coly = FAKECUBE_SAMPLE_FNC(d.zx).rgb;
-    vec3 colz = FAKECUBE_SAMPLE_FNC(d.xy).rgb;
-    vec3 n = d*d;
+    vec3 colx = FAKECUBE_SAMPLE_FNC(_normal.yz).rgb;
+    vec3 coly = FAKECUBE_SAMPLE_FNC(_normal.zx).rgb;
+    vec3 colz = FAKECUBE_SAMPLE_FNC(_normal.xy).rgb;
+    vec3 n = _normal*_normal;
     return (colx*n.x + coly*n.y + colz*n.z)/(n.x+n.y+n.z);
 
     #elif defined(FAKECUBE_ONLYXWALL)

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -1,6 +1,6 @@
 /*
 original_author: Patricio Gonzalez Vivo
-description: raymarching template where it needs to define a vec4 raymarchMSap( in vec3 pos ) 
+description: raymarching template where it needs to define a vec4 raymarchMap( in vec3 pos ) 
 use: <vec4> raymarch(<vec3> camera, <vec2> st)
 options:
     - LIGHT_POSITION: in glslViewer is u_light


### PR DESCRIPTION
Resolve custom fakecube uv undeclared error that previously use 'd' variable instead of '_normal'. Also fix the typo issue raised by `Lutymane:patch-1` https://github.com/patriciogonzalezvivo/lygia/pull/61 .

I tried your custom fake cube! LOVE IT!! 🚀🥳 I've been searching for this method for me to do custom fakeCube without using samplerCube/cubemap texture by using `envMap` function!