### PR TITLE
Update README.md to add degit instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ or as a submodule:
     git submodule add https://github.com/patriciogonzalezvivo/lygia.git
 ```
 
+or you may clone LYGIA without the git history and reduce the project size (9MB+) with the following command:
+
+```bash
+    npx degit https://github.com/patriciogonzalezvivo/lygia.git lygia
+```
+
 ### LYGIA on the cloud
 
 If you are working on a **cloud platform** you probably want to resolve the dependencies without needing to install anything. Just add a link to `https://lygia.xyz/resolve.js` (JS) or `https://lygia.xyz/resolve.esm.js` (ES6 module): 


### PR DESCRIPTION
Per your suggestion in the issue #44,

added another way of cloning LYGIA to README. The degit command will exclude git history to save project size (about 9MB) and download faster.