### PR TITLE
Fix broken include paths

### DIFF
--- a/geometry/aabb.glsl
+++ b/geometry/aabb.glsl
@@ -1,4 +1,4 @@
-#include "aabb/center.glsl"
+#include "aabb/centroid.glsl"
 #include "aabb/contain.glsl"
 #include "aabb/diagonal.glsl"
 #include "aabb/expand.glsl"

--- a/geometry/aabb.hlsl
+++ b/geometry/aabb.hlsl
@@ -1,4 +1,4 @@
-#include "aabb/center.hlsl"
+#include "aabb/centroid.hlsl"
 #include "aabb/contain.hlsl"
 #include "aabb/diagonal.hlsl"
 #include "aabb/expand.hlsl"

--- a/geometry/aabb/centroid.hlsl
+++ b/geometry/aabb/centroid.hlsl
@@ -3,7 +3,7 @@
 /*
 original_author: Patricio Gonzalez Vivo
 description: return center of a AABB
-use: <float3> centrood(<AABB> box) 
+use: <float3> centroid(<AABB> box) 
 */
 
 #ifndef FNC_AABB_CENTROID


### PR DESCRIPTION
Hi,
This small PR fixes broken includes in aabb.glsl and aabb.hlsl (`aabb/center.*` instead of `aabb/centroid.*`), as well as a typo in the `use` field of the documentation of `centroid.hlsl` (`centrood` instead of `centroid`).

Regards, TJ