### PR TITLE
fix typo on SAMPLER_FNC function call

### DIFF
--- a/color/dither/blueNoise.glsl
+++ b/color/dither/blueNoise.glsl
@@ -64,7 +64,7 @@ vec3 ditherBlueNoise(SAMPLER_TYPE tex, in vec3 rgb, const HIGHP in float time) {
     #endif
         
     #ifdef DITHER_BLUENOISE_CHROMATIC
-    vec3 bn = SAM_PLER_FNC(tex, st * blueNoiseTexturePixel).rgb;
+    vec3 bn = SAMPLER_FNC(tex, st * blueNoiseTexturePixel).rgb;
     vec3 bn_tri = vec3( remap_noise_tri_erp(bn.x), 
                         remap_noise_tri_erp(bn.y), 
                         remap_noise_tri_erp(bn.z) );

--- a/color/dither/blueNoise.hlsl
+++ b/color/dither/blueNoise.hlsl
@@ -52,7 +52,7 @@ float3 ditherBlueNoise(SAMPLER_TYPE tex, in float3 rgb, float2 fragcoord, const 
     #endif
         
     #ifdef DITHER_BLUENOISE_CHROMATIC
-    float3 bn = SAM_PLER_FNC(tex, fragcoord * blueNoiseTexturePixel).rgb;
+    float3 bn = SAMPLER_FNC(tex, fragcoord * blueNoiseTexturePixel).rgb;
     float3 bn_tri = float3( remap_noise_tri_erp(bn.x), 
                         remap_noise_tri_erp(bn.y), 
                         remap_noise_tri_erp(bn.z) );


### PR DESCRIPTION
removed an unnecessary underscore character in the SAMPLER_FNC call on ln 67 in color/dither/blueNoise.glsl