### PR TITLE
removed unterminated define in rgb2yiq.hlsl

### DIFF
--- a/color/space/rgb2yiq.hlsl
+++ b/color/space/rgb2yiq.hlsl
@@ -8,9 +8,6 @@ use: <float3|float4> rgb2yiq(<float3|float4> color)
 
 #ifndef FNC_RGB2YIQ
 #define FNC_RGB2YIQ
-
-#ifndef FNC_RGB2YIQ
-#define FNC_RGB2YIQ
 const float3x3 rgb2yiq_mat = float3x3(
     0.300,  0.5900,  0.1100, 
     0.599, -0.2773, -0.3217, 


### PR DESCRIPTION
I'm starting to go through the old unity samples and update them to the latest lygia. There are a few hlsl errors that are failing to compile. Some have me stumped, but I'll try to push up the simple ones like this as I get through them.