### PR TITLE
redefined epsilon in colliding files

### DIFF
--- a/color/space/rgb2srgb.hlsl
+++ b/color/space/rgb2srgb.hlsl
@@ -4,8 +4,8 @@ description: Converts a linear RGB color to sRGB color space.
 use: <float|float3\float4> rgb2srgb(<float|float3|float4> srgb)
 */
 
-#ifndef SRGB_EPSILON 
-#define SRGB_EPSILON 0.00000001
+#ifndef RGB2SRGB_EPSILON
+#define RGB2SRGB_EPSILON 0.00000001
 #endif
 
 #ifndef FNC_RGB2SRGB
@@ -16,7 +16,7 @@ float rgb2srgb(float channel) {
 }
 
 float3 rgb2srgb(float3 rgb) {
-    return saturate(float3(rgb2srgb(rgb[0] - SRGB_EPSILON), rgb2srgb(rgb[1] - SRGB_EPSILON), rgb2srgb(rgb[2] - SRGB_EPSILON)));
+    return saturate(float3(rgb2srgb(rgb[0] - RGB2SRGB_EPSILON), rgb2srgb(rgb[1] - RGB2SRGB_EPSILON), rgb2srgb(rgb[2] - RGB2SRGB_EPSILON)));
 }
 
 float4 rgb2srgb(float4 rgb) {

--- a/color/space/srgb2rgb.hlsl
+++ b/color/space/srgb2rgb.hlsl
@@ -4,8 +4,8 @@ description: sRGB to linear RGB conversion.
 use: <float|float3\float4> srgb2rgb(<float|float3|float4> srgb)
 */
 
-#ifndef SRGB_EPSILON 
-#define SRGB_EPSILON 0.00000001
+#ifndef SRGB2RGB_EPSILON
+#define SRGB2RGB_EPSILON 0.00000001
 #endif
 
 #ifndef FNC_SRGB2RGB
@@ -19,7 +19,7 @@ float srgb2rgb(float channel) {
 }
 
 float3 srgb2rgb(float3 srgb) {
-    return float3(srgb2rgb(srgb[0] + SRGB_EPSILON), srgb2rgb(srgb[1] + SRGB_EPSILON), srgb2rgb(srgb[2] + SRGB_EPSILON));
+    return float3(srgb2rgb(srgb[0] + SRGB2RGB_EPSILON), srgb2rgb(srgb[1] + SRGB2RGB_EPSILON), srgb2rgb(srgb[2] + SRGB2RGB_EPSILON));
 }
 
 float4 srgb2rgb(float4 srgb) {


### PR DESCRIPTION
closes #103 

I'm not sure why this is an issue to begin with. These are getting imported into the same compilation unit when they collide. For some reason #ifndef isn't working properly across them.