### PR TITLE
Fix: undeclared 'color' identifier in vibrance.glsl

### DIFF
--- a/color/vibrance.glsl
+++ b/color/vibrance.glsl
@@ -21,5 +21,5 @@ vec3 vibrance(in vec3 v, in float vi) {
     return mix(vec3(lum), v, 1.0 + (vi * 1.0 - (sign(vi) * sat)));
 }
 
-vec4 vibrance(in vec4 v, in float vi) { return vec4( vibrance(v.rgb, vi), color.a); }
+vec4 vibrance(in vec4 v, in float vi) { return vec4( vibrance(v.rgb, vi), v.a); }
 #endif


### PR DESCRIPTION
Fixes what appears to be a refactor oversight at https://github.com/patriciogonzalezvivo/lygia/commit/1bed3df3091647377bfa5e9fe55bfb4e93381483.