### PR TITLE
Capitalize first character of descriptions

### DIFF
--- a/animation/easing/bounce.glsl
+++ b/animation/easing/bounce.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: bounce easing. From https://github.com/stackgl/glsl-easings
+description: Bounce easing. From https://github.com/stackgl/glsl-easings
 use: 
     - <float> bounceIn(<float> x)
     - <float> bounceOut(<float> x)

--- a/animation/easing/bounce.hlsl
+++ b/animation/easing/bounce.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: bounce easing. From https://github.com/stackgl/glsl-easings
+description: Bounce easing. From https://github.com/stackgl/glsl-easings
 use: bounce<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/bounceIn.glsl
+++ b/animation/easing/bounceIn.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: bounce in easing. From https://github.com/stackgl/glsl-easings
+description: Bounce in easing. From https://github.com/stackgl/glsl-easings
 use: <float> bounceIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/eduardfossas/lygia-study-examples/main/animation/e_EasingBounce.frag

--- a/animation/easing/bounceInOut.glsl
+++ b/animation/easing/bounceInOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: bounce in/out easing. From https://github.com/stackgl/glsl-easings
+description: Bounce in/out easing. From https://github.com/stackgl/glsl-easings
 use: <float> bounceInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/eduardfossas/lygia-study-examples/main/animation/e_EasingBounce.frag

--- a/animation/easing/bounceOut.glsl
+++ b/animation/easing/bounceOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: bounce out easing. From https://github.com/stackgl/glsl-easings
+description: Bounce out easing. From https://github.com/stackgl/glsl-easings
 use: <float> bounceOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/eduardfossas/lygia-study-examples/main/animation/e_EasingBounce.frag

--- a/animation/easing/circular.glsl
+++ b/animation/easing/circular.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: circular easing. From https://github.com/stackgl/glsl-easings
+description: Circular easing. From https://github.com/stackgl/glsl-easings
 use: circular<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/circular.hlsl
+++ b/animation/easing/circular.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: circular easing. From https://github.com/stackgl/glsl-easings
+description: Circular easing. From https://github.com/stackgl/glsl-easings
 use: circular<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/circularIn.glsl
+++ b/animation/easing/circularIn.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: circular in easing. From https://github.com/stackgl/glsl-easings
+description: Circular in easing. From https://github.com/stackgl/glsl-easings
 use: circularIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/circularInOut.glsl
+++ b/animation/easing/circularInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: circular in/out easing. From https://github.com/stackgl/glsl-easings
+description: Circular in/out easing. From https://github.com/stackgl/glsl-easings
 use: circularInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/circularOut.glsl
+++ b/animation/easing/circularOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: circular out easing. From https://github.com/stackgl/glsl-easings
+description: Circular out easing. From https://github.com/stackgl/glsl-easings
 use: circularOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/cubic.glsl
+++ b/animation/easing/cubic.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: cubic easing. From https://github.com/stackgl/glsl-easings
+description: Cubic easing. From https://github.com/stackgl/glsl-easings
 use: cubic<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/cubic.hlsl
+++ b/animation/easing/cubic.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: cubic easing. From https://github.com/stackgl/glsl-easings
+description: Cubic easing. From https://github.com/stackgl/glsl-easings
 use: cubic<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/cubicIn.glsl
+++ b/animation/easing/cubicIn.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: cubic in easing. From https://github.com/stackgl/glsl-easings
+description: Cubic in easing. From https://github.com/stackgl/glsl-easings
 use: cubicIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/cubicInOut.glsl
+++ b/animation/easing/cubicInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: cubic in/out easing. From https://github.com/stackgl/glsl-easings
+description: Cubic in/out easing. From https://github.com/stackgl/glsl-easings
 use: cubicInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/cubicOut.glsl
+++ b/animation/easing/cubicOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: cubic out easing. From https://github.com/stackgl/glsl-easings
+description: Cubic out easing. From https://github.com/stackgl/glsl-easings
 use: cubicOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/elastic.glsl
+++ b/animation/easing/elastic.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: elastic easing. From https://github.com/stackgl/glsl-easings
+description: Elastic easing. From https://github.com/stackgl/glsl-easings
 use: elastic<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/elastic.hlsl
+++ b/animation/easing/elastic.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: elastic easing. From https://github.com/stackgl/glsl-easings
+description: Elastic easing. From https://github.com/stackgl/glsl-easings
 use: elastic<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/elasticIn.glsl
+++ b/animation/easing/elasticIn.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: elastic in easing. From https://github.com/stackgl/glsl-easings
+description: Elastic in easing. From https://github.com/stackgl/glsl-easings
 use: elasticIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/elasticInOut.glsl
+++ b/animation/easing/elasticInOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: elastic in/out easing. From https://github.com/stackgl/glsl-easings
+description: Elastic in/out easing. From https://github.com/stackgl/glsl-easings
 use: elasticInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/elasticOut.glsl
+++ b/animation/easing/elasticOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: elastic out easing. From https://github.com/stackgl/glsl-easings
+description: Elastic out easing. From https://github.com/stackgl/glsl-easings
 use: elasticOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/exponential.glsl
+++ b/animation/easing/exponential.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: exponential easing. From https://github.com/stackgl/glsl-easings
+description: Exponential easing. From https://github.com/stackgl/glsl-easings
 use: exponential<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/exponential.hlsl
+++ b/animation/easing/exponential.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: exponential easing. From https://github.com/stackgl/glsl-easings
+description: Exponential easing. From https://github.com/stackgl/glsl-easings
 use: exponential<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/exponentialIn.glsl
+++ b/animation/easing/exponentialIn.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: exponential in easing. From https://github.com/stackgl/glsl-easings
+description: Exponential in easing. From https://github.com/stackgl/glsl-easings
 use: exponentialIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/exponentialInOut.glsl
+++ b/animation/easing/exponentialInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: exponential in/out easing. From https://github.com/stackgl/glsl-easings
+description: Exponential in/out easing. From https://github.com/stackgl/glsl-easings
 use: exponentialInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/exponentialOut.glsl
+++ b/animation/easing/exponentialOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: exponential out easing. From https://github.com/stackgl/glsl-easings
+description: Exponential out easing. From https://github.com/stackgl/glsl-easings
 use: exponentialOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quadratic.glsl
+++ b/animation/easing/quadratic.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quadrtic easing. From https://github.com/stackgl/glsl-easings
+description: Quadrtic easing. From https://github.com/stackgl/glsl-easings
 use: quadratic<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quadratic.hlsl
+++ b/animation/easing/quadratic.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quadrtic easing. From https://github.com/stackgl/glsl-easings
+description: Quadrtic easing. From https://github.com/stackgl/glsl-easings
 use: quadratic<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/quadraticIn.glsl
+++ b/animation/easing/quadraticIn.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quadrtic in easing. From https://github.com/stackgl/glsl-easings
+description: Quadrtic in easing. From https://github.com/stackgl/glsl-easings
 use: quadraticIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quadraticInOut.glsl
+++ b/animation/easing/quadraticInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quadrtic in/out easing. From https://github.com/stackgl/glsl-easings
+description: Quadrtic in/out easing. From https://github.com/stackgl/glsl-easings
 use: quadraticInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quadraticOut.glsl
+++ b/animation/easing/quadraticOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quadrtic out easing. From https://github.com/stackgl/glsl-easings
+description: Quadrtic out easing. From https://github.com/stackgl/glsl-easings
 use: quadraticOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quartic.glsl
+++ b/animation/easing/quartic.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quartic easing. From https://github.com/stackgl/glsl-easings
+description: Quartic easing. From https://github.com/stackgl/glsl-easings
 use: quartic<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quartic.hlsl
+++ b/animation/easing/quartic.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quartic easing. From https://github.com/stackgl/glsl-easings
+description: Quartic easing. From https://github.com/stackgl/glsl-easings
 use: quartic<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/quarticIn.glsl
+++ b/animation/easing/quarticIn.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quartic in easing. From https://github.com/stackgl/glsl-easings
+description: Quartic in easing. From https://github.com/stackgl/glsl-easings
 use: quarticIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quarticInOut.glsl
+++ b/animation/easing/quarticInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quartic in/out easing. From https://github.com/stackgl/glsl-easings
+description: Quartic in/out easing. From https://github.com/stackgl/glsl-easings
 use: quarticInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quarticOut.glsl
+++ b/animation/easing/quarticOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quartic out easing. From https://github.com/stackgl/glsl-easings
+description: Quartic out easing. From https://github.com/stackgl/glsl-easings
 use: quarticOut<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quintic.glsl
+++ b/animation/easing/quintic.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quintic easing. From https://github.com/stackgl/glsl-easings
+description: Quintic easing. From https://github.com/stackgl/glsl-easings
 use: quintic<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quintic.hlsl
+++ b/animation/easing/quintic.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quintic easing. From https://github.com/stackgl/glsl-easings
+description: Quintic easing. From https://github.com/stackgl/glsl-easings
 use: quintic<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/quinticInOut.glsl
+++ b/animation/easing/quinticInOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quintic in/out easing. From https://github.com/stackgl/glsl-easings
+description: Quintic in/out easing. From https://github.com/stackgl/glsl-easings
 use: quinticInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/quinticOut.glsl
+++ b/animation/easing/quinticOut.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: quintic out easing. From https://github.com/stackgl/glsl-easings
+description: Quintic out easing. From https://github.com/stackgl/glsl-easings
 use: quinticOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/sine.glsl
+++ b/animation/easing/sine.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: sine easing. From https://github.com/stackgl/glsl-easings
+description: Sine easing. From https://github.com/stackgl/glsl-easings
 use: sine<In|Out|InOut>(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/sine.hlsl
+++ b/animation/easing/sine.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: sine easing. From https://github.com/stackgl/glsl-easings
+description: Sine easing. From https://github.com/stackgl/glsl-easings
 use: sine<In|Out|InOut>(<float> x)
 */
 

--- a/animation/easing/sineIn.glsl
+++ b/animation/easing/sineIn.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: sine in easing. From https://github.com/stackgl/glsl-easings
+description: Sine in easing. From https://github.com/stackgl/glsl-easings
 use: sineIn(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/sineInOut.glsl
+++ b/animation/easing/sineInOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: sine in/out easing. From https://github.com/stackgl/glsl-easings
+description: Sine in/out easing. From https://github.com/stackgl/glsl-easings
 use: sineInOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/animation/easing/sineOut.glsl
+++ b/animation/easing/sineOut.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: sine out easing. From https://github.com/stackgl/glsl-easings
+description: Sine out easing. From https://github.com/stackgl/glsl-easings
 use: sineOut(<float> x)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/animation_easing.frag

--- a/color/brightnessContrast.glsl
+++ b/color/brightnessContrast.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: modify brightness and contrast
+description: Modify brightness and contrast
 use: brightnessContrast(<float|vec3|vec4> color, <float> brightness, <float> amcontrastount)
 */
 

--- a/color/brightnessContrast.hlsl
+++ b/color/brightnessContrast.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: modify brightness and contrast
+description: Modify brightness and contrast
 use: brightnessContrast(<float|float3|float4> color, <float> brightness, <float> amcontrastount)
 */
 

--- a/color/brightnessMatrix.glsl
+++ b/color/brightnessMatrix.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the brightness of any color
+description: Generate a matrix to change a the brightness of any color
 use: brightnessMatrix(<float> amount)
 */
 

--- a/color/brightnessMatrix.hlsl
+++ b/color/brightnessMatrix.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the brightness of any color
+description: Generate a matrix to change a the brightness of any color
 use: brightnessMatrix(<float> amount)
 */
 

--- a/color/contrast.glsl
+++ b/color/contrast.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: bias high pass
+description: Bias high pass
 use: <vec4|vec3|float> contrast(<vec4|vec3|float> value, <float> amount)
 */
 

--- a/color/contrast.hlsl
+++ b/color/contrast.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: bias high pass
+description: Bias high pass
 use: <float4|float3|float> contrast(<float4|float3|float> value, <float> amount)
 */
 

--- a/color/contrastMatrix.glsl
+++ b/color/contrastMatrix.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the contrast of any color
+description: Generate a matrix to change a the contrast of any color
 use: contrastMatrix(<float> amount)
 */
 

--- a/color/contrastMatrix.hlsl
+++ b/color/contrastMatrix.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the contrast of any color
+description: Generate a matrix to change a the contrast of any color
 use: contrastMatrix(<float> amount)
 */
 

--- a/color/daltonize.glsl
+++ b/color/daltonize.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo  
-description: daltonize functions based on https://web.archive.org/web/20081014161121/http://www.colorjack.com/labs/colormatrix/ http://www.daltonize.org/search/label/Daltonize
+description: Daltonize functions based on https://web.archive.org/web/20081014161121/http://www.colorjack.com/labs/colormatrix/ http://www.daltonize.org/search/label/Daltonize
 use: <vec3|vec4> daltonize(<vec3|vec4> rgb)
 options:
     DALTONIZE_FNC: daltonizeProtanope, daltonizeProtanopia, daltonizeProtanomaly, daltonizeDeuteranope, daltonizeDeuteranopia, daltonizeDeuteranomaly, daltonizeTritanope, daltonizeTritanopia, daltonizeTritanomaly, daltonizeAchromatopsia and daltonizeAchromatomaly

--- a/color/daltonize.hlsl
+++ b/color/daltonize.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo  
-description: daltonize functions based on https://web.archive.org/web/20081014161121/http://www.colorjack.com/labs/colormatrix/ http://www.daltonize.org/search/label/Daltonize
+description: Daltonize functions based on https://web.archive.org/web/20081014161121/http://www.colorjack.com/labs/colormatrix/ http://www.daltonize.org/search/label/Daltonize
 use: <float3|float4> daltonize(<float3|float4> rgb)
 options:
     DALTONIZE_FNC: daltonizeProtanope, daltonizeProtanopia, daltonizeProtanomaly, daltonizeDeuteranope, daltonizeDeuteranopia, daltonizeDeuteranomaly, daltonizeTritanope, daltonizeTritanopia, daltonizeTritanomaly, daltonizeAchromatopsia and daltonizeAchromatomaly

--- a/color/desaturate.glsl
+++ b/color/desaturate.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: change saturation of a color
+description: Change saturation of a color
 use: desaturate(<float|vec3|vec4> color, float amount)
 */
 

--- a/color/desaturate.hlsl
+++ b/color/desaturate.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: change saturation of a color
+description: Change saturation of a color
 use: desaturate(<float|float3|float4> color, float amount)
 */
 

--- a/color/distance.glsl
+++ b/color/distance.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: perceptual distance between two color according to CIE94 https://en.wikipedia.org/wiki/Color_difference#CIE94
+description: Perceptual distance between two color according to CIE94 https://en.wikipedia.org/wiki/Color_difference#CIE94
 use: colorDistance(<vec3|vec4> rgbA, <vec3|vec4> rgbA)
 options:
     COLORDISTANCE_FNC: colorDistanceLABCIE94, colorDistanceLAB, colorDistanceYCbCr, colorDistanceYPbPr, colorDistanceYUV, colorDistanceOKLAB

--- a/color/distance.hlsl
+++ b/color/distance.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: perceptual distance between two color according to CIE94 https://en.wikipedia.org/wiki/Color_difference#CIE94
+description: Perceptual distance between two color according to CIE94 https://en.wikipedia.org/wiki/Color_difference#CIE94
 use: colorDistance(<float3|float4> rgbA, <float3|float4> rgbA)
 options:
     COLORDISTANCE_FNC: colorDistanceLABCIE94, colorDistanceLAB, colorDistanceYCbCr, colorDistanceYPbPr, colorDistanceYUV, colorDistanceOKLAB

--- a/color/dither.glsl
+++ b/color/dither.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: set of dither methods
+description: Set of dither methods
 use: <vec4|vec3|float> dither(<vec4|vec3|float> value[, <float> time])
 Options:
     - DITHER_FNC

--- a/color/dither.hlsl
+++ b/color/dither.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: set of dither methods
+description: Set of dither methods
 use: <float4|float3|float> dither(<float4|float3|float> value[, <float> time])
 Options:
     - DITHER_FNC

--- a/color/exposure.glsl
+++ b/color/exposure.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: change the exposure of a color
+description: Change the exposure of a color
 use: exposure(<float|vec3|vec4> color, float amount)
 */
 

--- a/color/exposure.hlsl
+++ b/color/exposure.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: change the exposure of a color
+description: Change the exposure of a color
 use: exposure(<float|float3|float4> color, float amount)
 */
 

--- a/color/hueShift.glsl
+++ b/color/hueShift.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Johan Ismael
-description: shifts color hue
+description: Shifts color hue
 use: hueShift(<vec3|vec4> color, <float> amount)
 */
 

--- a/color/hueShift.hlsl
+++ b/color/hueShift.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Johan Ismael
-description: shifts color hue
+description: Shifts color hue
 use: hueShift(<float3|float4> color, <float> amount)
 */
 

--- a/color/luma.glsl
+++ b/color/luma.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: get the luminosity of a color. From https://github.com/hughsk/glsl-luma/blob/master/index.glsl
+description: Get the luminosity of a color. From https://github.com/hughsk/glsl-luma/blob/master/index.glsl
 use: luma(<vec3|vec4> color)
 */
 

--- a/color/luma.hlsl
+++ b/color/luma.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Hugh Kennedy (https://github.com/hughsk)
-description: get the luminosity of a color. From https://github.com/hughsk/glsl-luma/blob/master/index.hlsl
+description: Get the luminosity of a color. From https://github.com/hughsk/glsl-luma/blob/master/index.hlsl
 use: luma(<float3|float4> color)
 */
 

--- a/color/palette/heatmap.cuh
+++ b/color/palette/heatmap.cuh
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: heatmap palette
+description: Heatmap palette
 use: <float3> heatmap(<float> value)
 */
 

--- a/color/palette/heatmap.glsl
+++ b/color/palette/heatmap.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: heatmap palette
+description: Heatmap palette
 use: <vec3> heatmap(<float> value)
 examples:
     - https://raw.githubusercontent.com/eduardfossas/lygia-study-examples/main/color/palette/heatmap.frag

--- a/color/palette/heatmap.hlsl
+++ b/color/palette/heatmap.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: heatmap palette
+description: Heatmap palette
 use: <float3> heatmap(<float> value)
 */
 

--- a/color/saturationMatrix.glsl
+++ b/color/saturationMatrix.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the saturation of any color
+description: Generate a matrix to change a the saturation of any color
 use: saturationMatrix(<float> amount)
 */
 

--- a/color/saturationMatrix.hlsl
+++ b/color/saturationMatrix.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: generate a matrix to change a the saturation of any color
+description: Generate a matrix to change a the saturation of any color
 use: saturationMatrix(<float> amount)
 */
 

--- a/color/space/YCbCr2rgb.glsl
+++ b/color/space/YCbCr2rgb.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert YCbCr to RGB according to https://en.wikipedia.org/wiki/YCbCr
+description: Converts YCbCr to RGB according to https://en.wikipedia.org/wiki/YCbCr
 use: YCbCr2rgb(<vec3|vec4> color)
 */
 

--- a/color/space/YCbCr2rgb.hlsl
+++ b/color/space/YCbCr2rgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert YCbCr to RGB according to https://en.wikipedia.org/wiki/YCbCr
+description: Converts YCbCr to RGB according to https://en.wikipedia.org/wiki/YCbCr
 use: YCbCr2rgb(<float3|float4> color)
 */
 

--- a/color/space/YPbPr2rgb.glsl
+++ b/color/space/YPbPr2rgb.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
+description: Pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
 use: YPbPr2RGB(<vec3|vec4> color)
 */
 

--- a/color/space/YPbPr2rgb.hlsl
+++ b/color/space/YPbPr2rgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
+description: Pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
 use: YPbPr2RGB(<float3|float4> color)
 */
 

--- a/color/space/cmyk2rgb.glsl
+++ b/color/space/cmyk2rgb.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert CMYK to RGB
+description: Convert CMYK to RGB
 use: cmyk2rgb(<vec4> cmyk)
 */
 

--- a/color/space/cmyk2rgb.hlsl
+++ b/color/space/cmyk2rgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert CMYK to RGB
+description: Convert CMYK to RGB
 use: cmyk2rgb(<float 4> cmyk)
 */
 

--- a/color/space/gamma2linear.glsl
+++ b/color/space/gamma2linear.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert from gamma to linear color space.
+description: Convert from gamma to linear color space.
 use: gamma2linear(<float|vec3|vec4> color)
 */
 

--- a/color/space/gamma2linear.hlsl
+++ b/color/space/gamma2linear.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert from gamma to linear color space.
+description: Convert from gamma to linear color space.
 use: gamma2linear(<float|float3|float4> color)
 */
 

--- a/color/space/k2rgb.glsl
+++ b/color/space/k2rgb.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
+description: Blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
 use: <vec3> k2rgb(<float> wavelength)
 */
 

--- a/color/space/k2rgb.hlsl
+++ b/color/space/k2rgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
+description: Blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
 use: <float3> w2rgb(<float> wavelength)
 */
 

--- a/color/space/linear2gamma.glsl
+++ b/color/space/linear2gamma.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert from linear to gamma color space.
+description: Convert from linear to gamma color space.
 use: linear2gamma(<float|vec3|vec4> color)
 */
 

--- a/color/space/linear2gamma.hlsl
+++ b/color/space/linear2gamma.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert from linear to gamma color space.
+description: Convert from linear to gamma color space.
 use: linear2gamma(<float|float3|float4> color)
 */
 

--- a/color/space/oklab2rgb.glsl
+++ b/color/space/oklab2rgb.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Bjorn Ottosson (@bjornornorn)
-description: oklab to linear RGB https://bottosson.github.io/posts/oklab/
+description: Oklab to linear RGB https://bottosson.github.io/posts/oklab/
 use: <vec3\vec4> oklab2rgb(<vec3|vec4> oklab)
 */
 

--- a/color/space/oklab2rgb.hlsl
+++ b/color/space/oklab2rgb.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Bjorn Ottosson (@bjornornorn)
-description: oklab to linear RGB https://bottosson.github.io/posts/oklab/
+description: Oklab to linear RGB https://bottosson.github.io/posts/oklab/
 use: <float3\float4> oklab2rgb(<float3|float4> oklab)
 */
 

--- a/color/space/oklab2rgb.wgsl
+++ b/color/space/oklab2rgb.wgsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Bjorn Ottosson (@bjornornorn)
-description: oklab to linear RGB https://bottosson.github.io/posts/oklab/
+description: Oklab to linear RGB https://bottosson.github.io/posts/oklab/
 use: <vec3\vec4> oklab2rgb(<vec3|vec4> oklab)
 */
 

--- a/color/space/oklab2srgb.glsl
+++ b/color/space/oklab2srgb.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Bjorn Ottosson (@bjornornorn)
-description: oklab to linear RGB https://bottosson.github.io/posts/oklab/
+description: Oklab to linear RGB https://bottosson.github.io/posts/oklab/
 use: <vec3\vec4> oklab2srgb(<vec3|vec4> oklab)
 */
 

--- a/color/space/oklab2srgb.hlsl
+++ b/color/space/oklab2srgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Bjorn Ottosson (@bjornornorn)
-description: oklab to linear RGB https://bottosson.github.io/posts/oklab/
+description: Oklab to linear RGB https://bottosson.github.io/posts/oklab/
 use: <float3\float4> oklab2srgb(<float3|float4> oklab)
 */
 

--- a/color/space/rgb2YCbCr.glsl
+++ b/color/space/rgb2YCbCr.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert RGB to YCbCr according to https://en.wikipedia.org/wiki/YCbCr
+description: Convert RGB to YCbCr according to https://en.wikipedia.org/wiki/YCbCr
 use: rgb2YCbCr(<vec3|vec4> color)
 */
 

--- a/color/space/rgb2YCbCr.hlsl
+++ b/color/space/rgb2YCbCr.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert RGB to YCbCr according to https://en.wikipedia.org/wiki/YCbCr
+description: Convert RGB to YCbCr according to https://en.wikipedia.org/wiki/YCbCr
 use: rgb2YCbCr(<float3|float4> color)
 */
 

--- a/color/space/rgb2YPbPr.glsl
+++ b/color/space/rgb2YPbPr.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
+description: Pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
 use: <vec3|vec4> rgb2YPbPr(<vec3|vec4> color)
 */
 

--- a/color/space/rgb2YPbPr.hlsl
+++ b/color/space/rgb2YPbPr.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
+description: Pass a color in RGB and get it in YPbPr from http://www.equasys.de/colorconversion.html
 use: <float3|float4> rgb2YPbPr(<float3|float4> color)
 */
 

--- a/color/space/rgb2cmyk.glsl
+++ b/color/space/rgb2cmyk.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert CMYK to RGB
+description: Convert CMYK to RGB
 use: rgb2cmyk(<vec3|vec4> rgba)
 */
 

--- a/color/space/rgb2cmyk.hlsl
+++ b/color/space/rgb2cmyk.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert CMYK to RGB
+description: Convert CMYK to RGB
 use: rgb2cmyk(<float3|float4> rgba)
 */
 

--- a/color/space/rgb2hsv.glsl
+++ b/color/space/rgb2hsv.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Sam Hocevar
-description: pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+description: Pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 use: rgb2hsv(<vec3|vec4> color)
 */
 

--- a/color/space/rgb2hsv.hlsl
+++ b/color/space/rgb2hsv.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Sam Hocevar
-description: pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+description: Pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 use: rgb2hsv(<float3|float4> color)
 */
 

--- a/color/space/rgb2hue.hlsl
+++ b/color/space/rgb2hue.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Sam Hocevar
-description: pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+description: Pass a color in RGB and get HSB color. From http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 use: <float> rgb2hue(<float3|float4> color)
 */
 

--- a/color/space/rgb2yuv.glsl
+++ b/color/space/rgb2yuv.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YUB
+description: Pass a color in RGB and get it in YUB
 use: rgb2yuv(<vec3|vec4> color)
 */
 

--- a/color/space/rgb2yuv.hlsl
+++ b/color/space/rgb2yuv.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in RGB and get it in YUB
+description: Pass a color in RGB and get it in YUB
 use: rgb2yuv(<float3|float4> color)
 */
 

--- a/color/space/w2rgb.glsl
+++ b/color/space/w2rgb.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: wavelength between 400~700 nm to RGB 
+description: Wavelength between 400~700 nm to RGB 
 use: <vec3> w2rgb(<float> wavelength)
 options: 
     W2RGB_FNC(X): spectral_zucconi, spectral_zucconi6, spectral_gems, spectral_geoffrey, 

--- a/color/space/w2rgb.hlsl
+++ b/color/space/w2rgb.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: wavelength to RGB
+description: Wavelength to RGB
 use: <float3> w2rgb(<float> wavelength)
 */
 

--- a/color/space/xyY2xyz.glsl
+++ b/color/space/xyY2xyz.glsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-    convert from xyY to XYZ
+    Converts from xyY to XYZ
 use: <vec3|vec4> xyY2xyz(<vec3|vec4> color)
 */
 

--- a/color/space/xyY2xyz.hlsl
+++ b/color/space/xyY2xyz.hlsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-    convert from xyY to XYZ
+    Converts from xyY to XYZ
 use: <float3|float4> xyY2xyz(<float3|float4> color)
 */
 

--- a/color/space/yiq2rgb.glsl
+++ b/color/space/yiq2rgb.glsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-   Convert a color in YIQ to linear RGB color. 
+   Converts a color in YIQ to linear RGB color. 
    From https://en.wikipedia.org/wiki/YIQ
 use: <vec3|vec4> yiq2rgb(<vec3|vec4> color)
 */

--- a/color/space/yiq2rgb.hlsl
+++ b/color/space/yiq2rgb.hlsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-   Convert a color in YIQ to linear RGB color. 
+   Converts a color in YIQ to linear RGB color. 
    From https://en.wikipedia.org/wiki/YIQQ
 use: <float3|float4> yiq2rgb(<float3|float4> color)
 */

--- a/color/space/yuv2rgb.glsl
+++ b/color/space/yuv2rgb.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in YUB and get RGB color
+description: Pass a color in YUB and get RGB color
 use: yuv2rgb(<vec3|vec4> color)
 */
 

--- a/color/space/yuv2rgb.hlsl
+++ b/color/space/yuv2rgb.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: pass a color in YUB and get RGB color
+description: Pass a color in YUB and get RGB color
 use: yuv2rgb(<float3|float4> color)
 */
 

--- a/color/tonemap/linear.glsl
+++ b/color/tonemap/linear.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: nan
-description: linear tonempa (no modifications are applied)
+description: Linear tonemap (no modifications are applied)
 use: <vec3|vec4> tonemapLinear(<vec3|vec4> x)
 */
 

--- a/color/tonemap/linear.hlsl
+++ b/color/tonemap/linear.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: nan
-description: linear tonempa (no modifications are applied)
+description: Linear tonemap (no modifications are applied)
 use: <float3|float4> tonemapLinear(<float3|float4> x)
 */
 

--- a/color/tonemap/uncharted2.glsl
+++ b/color/tonemap/uncharted2.glsl
@@ -1,6 +1,6 @@
 /*
 author: John Hable
-description: tonemapping function from presentation, uncharted 2 HDR Lighting, Page 142 to 143
+description: Tonemapping function from presentation, uncharted 2 HDR Lighting, Page 142 to 143
 use: <vec3|vec4> tonemapUncharted2(<vec3|vec4> x)
 */
 

--- a/color/tonemap/uncharted2.hlsl
+++ b/color/tonemap/uncharted2.hlsl
@@ -1,6 +1,6 @@
 /*
 author: John Hable
-description: tonemapping function from presentation. Uncharted 2 HDR Lighting, Page 142 to 143
+description: Tonemapping function from presentation. Uncharted 2 HDR Lighting, Page 142 to 143
 use: <float3|float4> tonemapUncharted2(<float3|float4> x)
 */
 

--- a/draw/bridge.glsl
+++ b/draw/bridge.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: create a bridge on a given in_value and draw a stroke inside that gap
+description: Create a bridge on a given in_value and draw a stroke inside that gap
 use: bridge(<float|vec2|vec3|vec4> in_value, <float> sdf, <float> size, <float> width)
 */
 

--- a/draw/bridge.hlsl
+++ b/draw/bridge.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: create a bridge on a given in_value and draw a stroke inside that gap
+description: Create a bridge on a given in_value and draw a stroke inside that gap
 use: bridge(<float|float2|float3|float4> in_value, <float> sdf, <float> size, <float> width)
 */
 

--- a/draw/circle.glsl
+++ b/draw/circle.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a circle filled or not. 
+description: Draw a circle filled or not. 
 use: circle(<vec2> st, <float> size [, <float> width])
 */
 

--- a/draw/circle.hlsl
+++ b/draw/circle.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a circle filled or not. 
+description: Draw a circle filled or not. 
 use: circle(<float2> st, <float> size [, <float> width])
 */
 

--- a/draw/colorChecker.glsl
+++ b/draw/colorChecker.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a color checker (Macbeth or Spyder)
+description: Draw a color checker (Macbeth or Spyder)
 use: 
     - colorChecker(<vec2> uv)
     - colorCheckerMacbeth(<vec2> uv)

--- a/draw/fill.glsl
+++ b/draw/fill.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: fill a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
+description: Fill a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
 use: fill(<float> sdf, <float> size [, <float> edge])
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/draw_shapes.frag

--- a/draw/fill.hlsl
+++ b/draw/fill.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: fill a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
+description: Fill a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
 use: fill(<float> sdf, <float> size [, <float> edge])
 */
 

--- a/draw/hex.glsl
+++ b/draw/hex.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a hexagon filled or not. 
+description: Draw a hexagon filled or not. 
 use: hex(<vec2> st, <float> size [, <float> width])
 */
 

--- a/draw/hex.hlsl
+++ b/draw/hex.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a hexagon filled or not. 
+description: Draw a hexagon filled or not. 
 use: hex(<float2> st, <float> size [, <float> width])
 */
 

--- a/draw/rect.glsl
+++ b/draw/rect.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a rectangel filled or not. 
+description: Draw a rectangel filled or not. 
 use: rect(<vec2> st, <vec2> size [, <float> width])
 */
 

--- a/draw/rect.hlsl
+++ b/draw/rect.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a rectangel filled or not. 
+description: Draw a rectangel filled or not. 
 use: rect(<float2> st, <float2> size [, <float> width])
 */
 

--- a/draw/stroke.glsl
+++ b/draw/stroke.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: fill a stroke in a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
+description: Fill a stroke in a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
 use: stroke(<float> sdf, <float> size, <float> width [, <float> edge])
 */
 

--- a/draw/stroke.hlsl
+++ b/draw/stroke.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: fill a stroke in a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
+description: Fill a stroke in a SDF. From PixelSpiritDeck https://github.com/patriciogonzalezvivo/PixelSpiritDeck
 use: stroke(<float> sdf, <float> size, <float> width [, <float> edge])
 */
 

--- a/draw/tri.glsl
+++ b/draw/tri.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a triangle filled or not. 
+description: Draw a triangle filled or not. 
 use: tri(<vec2> st, <float> size [, <float> width])
 */
 

--- a/draw/tri.hlsl
+++ b/draw/tri.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: draw a triangle filled or not. 
+description: Draw a triangle filled or not. 
 use: tri(<float2> st, <float> size [, <float> width])
 */
 

--- a/filter/boxBlur.hlsl
+++ b/filter/boxBlur.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: given a texture return a simple box blured pixel
+description: Given a texture return a simple box blured pixel
 use: boxBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset)
 options:
     - BOXBLUR_2D: default to 1D

--- a/filter/boxBlur/1D.glsl
+++ b/filter/boxBlur/1D.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple one dimentional box blur, to be applied in two passes
+description: Simple one dimentional box blur, to be applied in two passes
 use: boxBlur1D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/1D.hlsl
+++ b/filter/boxBlur/1D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple one dimentional box blur, to be applied in two passes
+description: Simple one dimentional box blur, to be applied in two passes
 use: boxBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D.glsl
+++ b/filter/boxBlur/2D.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimentional box blur, so can be apply in a single pass
 use: boxBlur2D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D.hlsl
+++ b/filter/boxBlur/2D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimentional box blur, so can be apply in a single pass
 use: boxBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D_fast9.glsl
+++ b/filter/boxBlur/2D_fast9.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimentional box blur, so can be apply in a single pass
 use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D_fast9.hlsl
+++ b/filter/boxBlur/2D_fast9.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimentional box blur, so can be apply in a single pass
 use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur.glsl
+++ b/filter/gaussianBlur.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: [Matt DesLauriers, Patricio Gonzalez Vivo]
-description: adapted versions from 5, 9 and 13 gaussian fast blur from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions from 5, 9 and 13 gaussian fast blur from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction [, const int kernelSize])
 options:
     - GAUSSIANBLUR_AMOUNT: gaussianBlur5 gaussianBlur9 gaussianBlur13 

--- a/filter/gaussianBlur.hlsl
+++ b/filter/gaussianBlur.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: [Matt DesLauriers, Patricio Gonzalez Vivo]
-description: adapted versions from 5, 9 and 13 gaussian fast blur from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions from 5, 9 and 13 gaussian fast blur from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction [, const int kernelSize])
 options:
     - GAUSSIANBLUR_AMOUNT: gaussianBlur5 gaussianBlur9 gaussianBlur13 

--- a/filter/gaussianBlur/1D.glsl
+++ b/filter/gaussianBlur/1D.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: one dimension Gaussian Blur to be applied in two passes
+description: One dimension Gaussian Blur to be applied in two passes
 use: gaussianBlur1D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction , const int kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D.hlsl
+++ b/filter/gaussianBlur/1D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: one dimension Gaussian Blur to be applied in two passes
+description: One dimension Gaussian Blur to be applied in two passes
 use: gaussianBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction , const int kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast13.glsl
+++ b/filter/gaussianBlur/1D_fast13.glsl
@@ -3,7 +3,7 @@
 /*
 function: gaussianBlur1D_fast13
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast13(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast13.hlsl
+++ b/filter/gaussianBlur/1D_fast13.hlsl
@@ -3,7 +3,7 @@
 /*
 function: gaussianBlur1D_fast13
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast13(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast5.glsl
+++ b/filter/gaussianBlur/1D_fast5.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast5(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast5.hlsl
+++ b/filter/gaussianBlur/1D_fast5.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast5(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast9.glsl
+++ b/filter/gaussianBlur/1D_fast9.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast9(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/1D_fast9.hlsl
+++ b/filter/gaussianBlur/1D_fast9.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Matt DesLauriers
-description: adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
 use: gaussianBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/2D.glsl
+++ b/filter/gaussianBlur/2D.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: two dimension Gaussian Blur to be applied in only one passes
+description: Two dimension Gaussian Blur to be applied in only one passes
 use: gaussianBlur2D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction , const int kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/gaussianBlur/2D.hlsl
+++ b/filter/gaussianBlur/2D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: two dimension Gaussian Blur to be applied in only one passes
+description: Two dimension Gaussian Blur to be applied in only one passes
 use: gaussianBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction , const int kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/laplacian.glsl
+++ b/filter/laplacian.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: laplacian filter
+description: Laplacian filter
 use: laplacian(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixels_scale [, <float> pixel_padding])
 options:
     - LAPLACIAN_TYPE: Return type, defaults to float

--- a/filter/laplacian.hlsl
+++ b/filter/laplacian.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: laplacian filter
+description: Laplacian filter
 use: laplacian(<SAMPLER_TYPE> texture, <float2> st, <float2> pixels_scale [, <float> pixel_padding])
 options:
     - LAPLACIAN_TYPE: Return type, defaults to float

--- a/filter/mean.glsl
+++ b/filter/mean.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Brad Larson
-description: adapted version of mean average sampling on four coorners of a sampled point from https://github.com/BradLarson/GPUImage2
+description: Adapted version of mean average sampling on four coorners of a sampled point from https://github.com/BradLarson/GPUImage2
 use: mean(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel)
 options:
     - MEAN_TYPE: defaults to vec4

--- a/filter/mean.hlsl
+++ b/filter/mean.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Brad Larson
-description: adapted version of mean average sampling on four coorners of a sampled point from https://github.com/BradLarson/GPUImage2
+description: Adapted version of mean average sampling on four coorners of a sampled point from https://github.com/BradLarson/GPUImage2
 use: mean(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel)
 options:
     - MEAN_TYPE: defaults to float4

--- a/filter/radialBlur.glsl
+++ b/filter/radialBlur.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: make a radial blur, with dir as the direction to the center and strength as the amount
+description: Make a radial blur, with dir as the direction to the center and strength as the amount
 use: radialBlur(<SAMPLER_TYPE> texture, <vec2> st, <vec2> dir [, <float> strength] )
 options:
     - RADIALBLUR_KERNELSIZE: Default 64 

--- a/filter/radialBlur.hlsl
+++ b/filter/radialBlur.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: make a radial blur, with dir as the direction to the center and strength as the amount
+description: Make a radial blur, with dir as the direction to the center and strength as the amount
 use: radialBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> dir [, <float> strength] )
 options:
     - RADIALBLUR_KERNELSIZE: Default 64 

--- a/filter/sharpen.glsl
+++ b/filter/sharpen.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sharpening filter
+description: Sharpening filter
 use: sharpen(<SAMPLER_TYPE> texture, <vec2> st, <vec2> renderSize [, float streanght])
 options:
     - SHARPEN_KERNELSIZE: Defaults 2

--- a/filter/sharpen.hlsl
+++ b/filter/sharpen.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sharpening filter
+description: Sharpening filter
 use: sharpen(<SAMPLER_TYPE> texture, <float2> st, <float2> renderSize [, float streanght])
 options:
     - SHARPEN_KERNELSIZE: Defaults 2

--- a/filter/sharpen/adaptive.glsl
+++ b/filter/sharpen/adaptive.glsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: bacondither
-description: adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
+description: Adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
 use: sharpen(<SAMPLER_TYPE> texture, <vec2> st, <vec2> renderSize [, float streanght])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/sharpen/adaptive.hlsl
+++ b/filter/sharpen/adaptive.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: bacondither
-description: adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
+description: Adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
 use: sharpen(<SAMPLER_TYPE> texture, <float2> st, <float2> renderSize [, float streanght])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/sharpen/fast.glsl
+++ b/filter/sharpen/fast.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Johan Ismael
-description: sharpening convolutional operation
+description: Sharpening convolutional operation
 use: sharpen(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/sharpen/fast.hlsl
+++ b/filter/sharpen/fast.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Johan Ismael
-description: sharpening convolutional operation
+description: Sharpening convolutional operation
 use: sharpen(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/generative/gnoise.glsl
+++ b/generative/gnoise.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: gradient Noise 
+description: Gradient Noise 
 use: gnoise(<float> x)
 */
 

--- a/generative/noised.glsl
+++ b/generative/noised.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Inigo Quilez
-description: returns 2D/3D value noise in the first channel and in the rest the derivatives. For more details read this nice article http://www.iquilezles.org/www/articles/gradientnoise/gradientnoise.htm
+description: Returns 2D/3D value noise in the first channel and in the rest the derivatives. For more details read this nice article http://www.iquilezles.org/www/articles/gradientnoise/gradientnoise.htm
 use: noised(<vec2|vec3> space)
 options:
     NOISED_QUINTIC_INTERPOLATION: Quintic interpolation on/off. Default is off.

--- a/generative/noised.hlsl
+++ b/generative/noised.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Inigo Quilez
-description: returns 2D/3D value noise in the first channel and in the rest the derivatives. For more details read this nice article http://www.iquilezles.org/www/articles/gradientnoise/gradientnoise.htm
+description: Returns 2D/3D value noise in the first channel and in the rest the derivatives. For more details read this nice article http://www.iquilezles.org/www/articles/gradientnoise/gradientnoise.htm
 use: noised(<float2|float3> space)
 options:
     NOISED_QUINTIC_INTERPOLATION: Quintic interpolation on/off. Default is off.

--- a/generative/random.glsl
+++ b/generative/random.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: ["Patricio Gonzalez Vivo", "David Hoskins", "Inigo Quilez"]
-description: pass a value and get some random normalize value between 0 and 1
+description: Pass a value and get some random normalize value between 0 and 1
 use: float random[2|3](<float|vec2|vec3> value)
 options:
     - RANDOM_HIGHER_RANGE: for working with a range over 0 and 1

--- a/generative/random.hlsl
+++ b/generative/random.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: ["Patricio Gonzalez Vivo", "David Hoskins", "Inigo Quilez"]
-description: pass a value and get some random normalize value between 0 and 1
+description: Pass a value and get some random normalize value between 0 and 1
 use: float random[2|3](<float|float2|float3> value)
 options:
     - RANDOM_HIGHER_RANGE: for working with a range over 0 and 1

--- a/generative/voronoise.glsl
+++ b/generative/voronoise.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Inigo Quiles
-description: cell noise https://iquilezles.org/articles/voronoise/
+description: Cell noise https://iquilezles.org/articles/voronoise/
 use: <float> voronoi(<vec3|vec2> pos, float voronoi, float _smoothness);
 options:
     VORONOI_RANDOM_FNC: nan

--- a/generative/voronoise.hlsl
+++ b/generative/voronoise.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Inigo Quiles
-description: cell noise https://iquilezles.org/articles/voronoise/
+description: Cell noise https://iquilezles.org/articles/voronoise/
 use: <float> voronoi(<float3|float2> pos, float voronoi, float _smoothness);
 options:
     VORONOI_RANDOM_FNC: 

--- a/geometry/aabb/centroid.cuh
+++ b/geometry/aabb/centroid.cuh
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: return center of a AABB
+description: Return center of a AABB
 use: <float3> centroid(<AABB> box) 
 */
 

--- a/geometry/aabb/centroid.glsl
+++ b/geometry/aabb/centroid.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: return center of a AABB
+description: Return center of a AABB
 use: <vec3> centroid(<AABB> box) 
 */
 

--- a/geometry/aabb/centroid.hlsl
+++ b/geometry/aabb/centroid.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: return center of a AABB
+description: Return center of a AABB
 use: <float3> centroid(<AABB> box) 
 */
 

--- a/geometry/aabb/diagonal.cuh
+++ b/geometry/aabb/diagonal.cuh
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patrincio Gonzalez Vivo
-description: return the diagonal vector of a AABB
+description: Return the diagonal vector of a AABB
 use: <float> diagonal(<AABB> box ) 
 */
 

--- a/geometry/aabb/diagonal.glsl
+++ b/geometry/aabb/diagonal.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patrincio Gonzalez Vivo
-description: return the diagonal vector of a AABB
+description: Return the diagonal vector of a AABB
 use: <float> diagonal(<AABB> box ) 
 */
 

--- a/geometry/aabb/diagonal.hlsl
+++ b/geometry/aabb/diagonal.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patrincio Gonzalez Vivo
-description: return the diagonal vector of a AABB
+description: Return the diagonal vector of a AABB
 use: <float> diagonal(<AABB> box ) 
 */
 

--- a/geometry/aabb/expand.glsl
+++ b/geometry/aabb/expand.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: expand AABB
+description: Expand AABB
 use: <bool> expand(<AABB> box, <AABB|vec3|float> point ) 
 */
 

--- a/geometry/aabb/intersect.cuh
+++ b/geometry/aabb/intersect.cuh
@@ -8,7 +8,7 @@
 /*
 contributors: Dominik Schmid 
 description: |
-    compute the near and far intersections of the cube (stored in the x and y components) using the slab method no intersection means vec.x > vec.y (really tNear > tFar) https://gist.github.com/DomNomNom/46bb1ce47f68d255fd5d
+    Compute the near and far intersections of the cube (stored in the x and y components) using the slab method no intersection means vec.x > vec.y (really tNear > tFar) https://gist.github.com/DomNomNom/46bb1ce47f68d255fd5d
 use: <float2> intersect(<AABB> box, <float3> rayOrigin, <float3> rayDir)
 */
 

--- a/geometry/aabb/intersect.glsl
+++ b/geometry/aabb/intersect.glsl
@@ -4,7 +4,7 @@
 /*
 contributors: Dominik Schmid 
 description: |
-    compute the near and far intersections of the cube (stored in the x and y components) using the slab method
+    Compute the near and far intersections of the cube (stored in the x and y components) using the slab method
     no intersection means vec.x > vec.y (really tNear > tFar) https://gist.github.com/DomNomNom/46bb1ce47f68d255fd5d
 use: <vec2> intersect(<AABB> box, <vec3> rayOrigin, <vec3> rayDir)
 */

--- a/geometry/aabb/intersect.hlsl
+++ b/geometry/aabb/intersect.hlsl
@@ -4,7 +4,7 @@
 /*
 contributors: Dominik Schmid 
 description: |
-    compute the near and far intersections of the cube (stored in the x and y components) using the slab method no intersection means vec.x > vec.y (really tNear > tFar) https://gist.github.com/DomNomNom/46bb1ce47f68d255fd5d
+    Compute the near and far intersections of the cube (stored in the x and y components) using the slab method no intersection means vec.x > vec.y (really tNear > tFar) https://gist.github.com/DomNomNom/46bb1ce47f68d255fd5d
 use: <float2> intersect(<AABB> box, <float3> rayOrigin, <float3> rayDir)
 */
 

--- a/geometry/aabb/intersection.cuh
+++ b/geometry/aabb/intersection.cuh
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: compute the intersection of two AABBs
+description: Compute the intersection of two AABBs
 use: <float2> intersect(<AABB> box, <float3> rayOrigin, <float3> rayDir)
 */
 

--- a/geometry/aabb/square.cuh
+++ b/geometry/aabb/square.cuh
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: square a AABB using the longest side
+description: Square an AABB using the longest side
 use: <void> square(<AABB> box) 
 */
 

--- a/geometry/aabb/square.glsl
+++ b/geometry/aabb/square.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: square a AABB using the longest side
+description: Square an AABB using the longest side
 use: <void> square(<AABB> box) 
 */
 

--- a/geometry/aabb/square.hlsl
+++ b/geometry/aabb/square.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: square a AABB using the longest side
+description: Square an AABB using the longest side
 use: <void> AABBsquare(<AABB> box) 
 */
 

--- a/geometry/triangle/area.cuh
+++ b/geometry/triangle/area.cuh
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the area of a triangle
+description: Returns the area of a triangle
 use: <float3> normal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/area.glsl
+++ b/geometry/triangle/area.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the area of a triangle
+description: Returns the area of a triangle
 use: <float3> normal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/area.hlsl
+++ b/geometry/triangle/area.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the area of a triangle
+description: Returns the area of a triangle
 use: <float3> normal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/barycentric.cuh
+++ b/geometry/triangle/barycentric.cuh
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <float3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/barycentric.glsl
+++ b/geometry/triangle/barycentric.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <vec3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/barycentric.hlsl
+++ b/geometry/triangle/barycentric.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <float3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/centroid.cuh
+++ b/geometry/triangle/centroid.cuh
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <float3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/centroid.glsl
+++ b/geometry/triangle/centroid.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <vec3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/centroid.hlsl
+++ b/geometry/triangle/centroid.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the centroid of a triangle
+description: Returns the centroid of a triangle
 use: <float3> centroid(<Triangle> tri) 
 */
 

--- a/geometry/triangle/closestPoint.cuh
+++ b/geometry/triangle/closestPoint.cuh
@@ -6,7 +6,7 @@
 
 /*
 contributors: 
-description: returns the closest point on the surface of a triangle
+description: Returns the closest point on the surface of a triangle
 use: <float3> closestDistance(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/closestPoint.glsl
+++ b/geometry/triangle/closestPoint.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: 
-description: returns the closest point on the surface of a triangle
+description: Returns the closest point on the surface of a triangle
 use: <vec3> closestDistance(<Triangle> tri, <vec3> _pos) 
 */
 

--- a/geometry/triangle/closestPoint.hlsl
+++ b/geometry/triangle/closestPoint.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: 
-description: returns the closest point on the surface of a triangle
+description: Returns the closest point on the surface of a triangle
 use: <float3> closestDistance(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/contain.cuh
+++ b/geometry/triangle/contain.cuh
@@ -4,7 +4,7 @@
 
 /*
 contributors: Thomas Müller & Alex Evans
-description: does the position lie within the triangle
+description: Does the position lie within the triangle
 use: <float3> contain(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/contain.glsl
+++ b/geometry/triangle/contain.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Thomas Müller & Alex Evans
-description: does the position lie within the triangle
+description: Does the position lie within the triangle
 use: <vec3> contain(<Triangle> tri, <vec3> _pos) 
 */
 

--- a/geometry/triangle/contain.hlsl
+++ b/geometry/triangle/contain.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Thomas Müller & Alex Evans
-description: does the position lie within the triangle
+description: Does the position lie within the triangle
 use: <float3> contain(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/distanceSq.cuh
+++ b/geometry/triangle/distanceSq.cuh
@@ -7,7 +7,7 @@
 
 /*
 contributors: Inigo Quiles
-description: returns the closest sq distance to the surface of a triangle
+description: Returns the closest sq distance to the surface of a triangle
 use: <float3> closestDistanceSq(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/distanceSq.glsl
+++ b/geometry/triangle/distanceSq.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Inigo Quiles
-description: returns the closest sq distance to the surface of a triangle
+description: Returns the closest sq distance to the surface of a triangle
 use: <vec3> closestDistanceSq(<Triangle> tri, <vec3> _pos) 
 */
 

--- a/geometry/triangle/distanceSq.hlsl
+++ b/geometry/triangle/distanceSq.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Inigo Quiles
-description: returns the closest sq distance to the surface of a triangle
+description: Returns the closest sq distance to the surface of a triangle
 use: <float3> closestDistanceSq(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/intersect.cuh
+++ b/geometry/triangle/intersect.cuh
@@ -7,7 +7,7 @@
 #include "../../lighting/ray.cuh"
 /*
 contributors: Inigo Quiles
-description: based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
+description: Based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
 use: <float> intersect(<Triangle> tri, <float3> rayOrigin, <float3> rayDir, out <float3> intersectionPoint)
 */
 

--- a/geometry/triangle/intersect.glsl
+++ b/geometry/triangle/intersect.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Inigo Quiles
-description: based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
+description: Based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
 use: <float> intersect(<Triangle> tri, <vec3> rayOrigin, <vec3> rayDir, out <vec3> intersectionPoint)
 */
 

--- a/geometry/triangle/intersect.hlsl
+++ b/geometry/triangle/intersect.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Inigo Quiles
-description: based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
+description: Based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
 use: <float> intersect(<Triangle> tri, <float3> rayOrigin, <float3> rayDir, out <float3> intersectionPoint)
 */
 

--- a/geometry/triangle/normal.cuh
+++ b/geometry/triangle/normal.cuh
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the normal of a triangle
+description: Returns the normal of a triangle
 use: <float3> getNormal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/normal.glsl
+++ b/geometry/triangle/normal.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the normal of a triangle
+description: Returns the normal of a triangle
 use: <vec33> getNormal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/normal.hlsl
+++ b/geometry/triangle/normal.hlsl
@@ -1,7 +1,7 @@
 #include "triangle.hlsl"
 /*
 contributors: Patricio Gonzalez Vivo
-description: returns the normal of a triangle
+description: Returns the normal of a triangle
 use: <float3> getNormal(<Triangle> tri) 
 */
 

--- a/geometry/triangle/signedDistance.cuh
+++ b/geometry/triangle/signedDistance.cuh
@@ -7,7 +7,7 @@
 
 /*
 contributors: 
-description: returns the signed distance from the surface of a triangle to a point
+description: Returns the signed distance from the surface of a triangle to a point
 use: <float3> closestDistance(<Triangle> tri, <float3> _pos) 
 */
 

--- a/geometry/triangle/signedDistance.glsl
+++ b/geometry/triangle/signedDistance.glsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: 
-description: returns the signed distance from the surface of a triangle to a point
+description: Returns the signed distance from the surface of a triangle to a point
 use: <vec3> closestDistance(<Triangle> tri, <vec3> _pos) 
 */
 

--- a/geometry/triangle/signedDistance.hlsl
+++ b/geometry/triangle/signedDistance.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: 
-description: returns the signed distance from the surface of a triangle to a point
+description: Returns the signed distance from the surface of a triangle to a point
 use: <float3> closestDistance(<Triangle> tri, <float3> _pos) 
 */
 

--- a/lighting/blackbody.glsl
+++ b/lighting/blackbody.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
+description: Blackbody in kelvin to RGB. Range between 0.0 and 40000.0 Kelvin
 use: <vec3> blackbody(<float> wavelength)
 */
 

--- a/lighting/debugCube.glsl
+++ b/lighting/debugCube.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Ignacio Castaño
-description: debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
+description: Debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
 use: <vec3> debugCube(<vec3> _normal, <float> cube_size, <float> lod)
 */
 

--- a/lighting/debugCube.hlsl
+++ b/lighting/debugCube.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Ignacio Castaño
-description: debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
+description: Debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
 use: <float3> debugCube(<float3> _norma, <float> cube_size, <float> lod)
 */
 

--- a/lighting/diffuse.glsl
+++ b/lighting/diffuse.glsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution
+description: Calculate diffuse contribution
 use: lightSpot(<vec3> _diffuseColor, <vec3> _specularColor, <vec3> _N, <vec3> _V, <float> _NoV, <float> _f0, out <vec3> _diffuse, out <vec3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/diffuse.hlsl
+++ b/lighting/diffuse.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution
+description: Calculate diffuse contribution
 use: lightSpot(<float3> _diffuseColor, <float3> _specularColor, <float3> _N, <float3> _V, <float> _NoV, <float> _f0, out <float3> _diffuse, out <float3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/diffuse/burley.glsl
+++ b/lighting/diffuse/burley.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using burley equation
+description: Calculate diffuse contribution using burley equation
 use: 
     - <float> diffuseBurley(<vec3> light, <vec3> normal [, <vec3> view, <float> roughness] )
     - <float> diffuseBurley(<vec3> L, <vec3> N, <vec3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/diffuse/burley.hlsl
+++ b/lighting/diffuse/burley.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using burley equation
+description: Calculate diffuse contribution using burley equation
 use: 
     - <float> diffuseBurley(<float3> light, <float3> normal [, <float3> view, <float> roughness] )
     - <float> diffuseBurley(<float3> L, <float3> N, <float3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/diffuse/lambert.glsl
+++ b/lighting/diffuse/lambert.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using lambert equation
+description: Calculate diffuse contribution using lambert equation
 use: 
     - <float> diffuseLambert(<vec3> light, <vec3> normal [, <vec3> view, <float> roughness] )
     - <float> diffuseLambert(<vec3> L, <vec3> N, <vec3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/diffuse/lambert.hlsl
+++ b/lighting/diffuse/lambert.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using lambert equation
+description: Calculate diffuse contribution using lambert equation
 use: 
     - <float> diffuseLambert(<float3> light, <float3> normal [, <float3> view, <float> roughness] )
     - <float> diffuseLambert(<float3> L, <float3> N, <float3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/diffuse/orenNayar.glsl
+++ b/lighting/diffuse/orenNayar.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using Oren and Nayar equation https://en.wikipedia.org/wiki/Oren%E2%80%93Nayar_reflectance_model
+description: Calculate diffuse contribution using Oren and Nayar equation https://en.wikipedia.org/wiki/Oren%E2%80%93Nayar_reflectance_model
 use: 
     - <float> diffuseOrenNayar(<vec3> light, <vec3> normal, <vec3> view, <float> roughness )
     - <float> diffuseOrenNayar(<vec3> L, <vec3> N, <vec3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/diffuse/orenNayar.hlsl
+++ b/lighting/diffuse/orenNayar.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate diffuse contribution using Oren and Nayar equation https://en.wikipedia.org/wiki/Oren%E2%80%93Nayar_reflectance_model
+description: Calculate diffuse contribution using Oren and Nayar equation https://en.wikipedia.org/wiki/Oren%E2%80%93Nayar_reflectance_model
 use: 
     - <float> diffuseOrenNayar(<float3> light, <float3> normal, <float3> view, <float> roughness )
     - <float> diffuseOrenNayar(<float3> L, <float3> N, <float3> V, <float> NoV, <float> NoL, <float> roughness)

--- a/lighting/envMap.glsl
+++ b/lighting/envMap.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get enviroment map light comming from a normal direction and acording to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates a fake cube
+description: Get enviroment map light comming from a normal direction and acording to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates a fake cube
 use: <vec3> envMap(<vec3> _normal, <float> _roughness [, <float> _metallic])
 options:
     - SCENE_CUBEMAP: pointing to the cubemap texture

--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -7,7 +7,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get enviroment map light comming from a normal direction and acording to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates a fake cube
+description: Get enviroment map light comming from a normal direction and acording to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates a fake cube
 use: <float3> envMap(<float3> _normal, <float> _roughness [, <float> _metallic])
 options:
     - CUBEMAP: pointing to the cubemap texture

--- a/lighting/fakeCube.glsl
+++ b/lighting/fakeCube.glsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: creates a fake cube and returns the value giving a normal direction
+description: Creates a fake cube and returns the value giving a normal direction
 use: <vec3> fakeCube(<vec3> _normal [, <float> _shininnes])
 options:
     - FAKECUBE_LIGHT_AMOUNT: amount of light to fake

--- a/lighting/fakeCube.hlsl
+++ b/lighting/fakeCube.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: creates a fake cube and returns the value giving a normal direction
+description: Creates a fake cube and returns the value giving a normal direction
 use: <float3> fakeCube(<float3> _normal [, <float> _shininnes])
 */
 

--- a/lighting/fresnel.glsl
+++ b/lighting/fresnel.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: resolve fresnel coeficient
+description: Resolve fresnel coeficient
 use: 
     - <float|vec3> fresnel(const <float|vec3> f0, <float> NoV)
 */

--- a/lighting/fresnel.hlsl
+++ b/lighting/fresnel.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: resolve fresnel coeficient
+description: Resolve fresnel coeficient
 use: 
     - <float3> fresnel(const <float3> f0, <float> LoH)
     - <float3> fresnel(<float3> _R, <float3> _f0, <float> _NoV)

--- a/lighting/fresnelReflection.hlsl
+++ b/lighting/fresnelReflection.hlsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: resolve fresnel coeficient
+description: Resolve fresnel coeficient
 use: 
     - <float3> fresnel(const <float3> f0, <float> LoH)
     - <float3> fresnel(<float3> _R, <float3> _f0, <float> _NoV)

--- a/lighting/gooch.glsl
+++ b/lighting/gooch.glsl
@@ -13,7 +13,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: render with a gooch stylistic shading model
+description: Render with a gooch stylistic shading model
 use: <vec4> gooch(<vec4> albedo, <vec3> normal, <vec3> light, <vec3> view, <float> roughness)
 options:
     - GOOCH_WARM: defualt vec3(0.25, 0.15, 0.0)

--- a/lighting/gooch.hlsl
+++ b/lighting/gooch.hlsl
@@ -9,7 +9,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: render with a gooch stylistic shading model
+description: Render with a gooch stylistic shading model
 use: <float4> gooch(<float4> albedo, <float3> normal, <float3> light, <float3> view, <float> roughness)
 options:
     - GOOCH_WARM: defualt float3(0.25, 0.15, 0.0)

--- a/lighting/ior/2eta.glsl
+++ b/lighting/ior/2eta.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: index of refraction to ratio of index of refraction
+description: Index of refraction to ratio of index of refraction
 use: <float|vec3|vec4> ior2eta(<float|vec3|vec4> ior)
 */
 

--- a/lighting/ior/2eta.hlsl
+++ b/lighting/ior/2eta.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: index of refraction to ratio of index of refraction
+description: Index of refraction to ratio of index of refraction
 use: <float|float3|float4> ior2eta(<float|float3|float4> ior)
 */
 

--- a/lighting/ior/2f0.glsl
+++ b/lighting/ior/2f0.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: index of refraction to reflectance at 0 degree https://handlespixels.wordpress.com/tag/f0-reflectance/
+description: Index of refraction to reflectance at 0 degree https://handlespixels.wordpress.com/tag/f0-reflectance/
 use: <float|vec3|vec4> ior2f0(<float|vec3|vec4> ior)
 */
 

--- a/lighting/ior/2f0.hlsl
+++ b/lighting/ior/2f0.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: index of refraction to reflectance at 0 degree https://handlespixels.wordpress.com/tag/f0-reflectance/
+description: Index of refraction to reflectance at 0 degree https://handlespixels.wordpress.com/tag/f0-reflectance/
 use: <float|float3|float4> ior2f0(<float|float3|float4> ior)
 */
 

--- a/lighting/light/directional.glsl
+++ b/lighting/light/directional.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate directional light
+description: Calculate directional light
 use: lightDirectional(<vec3> _diffuseColor, <vec3> _specularColor, <vec3> _N, <vec3> _V, <float> _NoV, <float> _f0, out <vec3> _diffuse, out <vec3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate directional light
+description: Calculate directional light
 use: lightDirectional(<float3> _diffuseColor, <float3> _specularColor, <float3> _N, <float3> _V, <float> _NoV, <float> _f0, out <float3> _diffuse, out <float3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/light/point.glsl
+++ b/lighting/light/point.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate point light
+description: Calculate point light
 use: lightPoint(<vec3> _diffuseColor, <vec3> _specularColor, <vec3> _N, <vec3> _V, <float> _NoV, <float> _f0, out <vec3> _diffuse, out <vec3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate point light
+description: Calculate point light
 use: lightPoint(<float3> _diffuseColor, <float3> _specularColor, <float3> _N, <float3> _V, <float> _NoV, <float> _f0, out <float3> _diffuse, out <float3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/light/spot.glsl
+++ b/lighting/light/spot.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate spot light
+description: Calculate spot light
 use: lightSpot(<vec3> _diffuseColor, <vec3> _specularColor, <vec3> _N, <vec3> _V, <float> _NoV, <float> _f0, out <vec3> _diffuse, out <vec3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/light/spot.hlsl
+++ b/lighting/light/spot.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate spot light
+description: Calculate spot light
 use: lightSpot(<float3> _diffuseColor, <float3> _specularColor, <float3> _N, <float3> _V, <float> _NoV, <float> _f0, out <float3> _diffuse, out <float3> _specular)
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/material/albedo.glsl
+++ b/lighting/material/albedo.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material BaseColor from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material BaseColor from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialAlbedo()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/albedo.hlsl
+++ b/lighting/material/albedo.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material BaseColor from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material BaseColor from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialAlbedo()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/emissive.glsl
+++ b/lighting/material/emissive.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material emissive property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material emissive property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialEmissive()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/emissive.hlsl
+++ b/lighting/material/emissive.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material emissive property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material emissive property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialEmissive()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/metallic.glsl
+++ b/lighting/material/metallic.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/metallic.hlsl
+++ b/lighting/material/metallic.hlsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/normal.glsl
+++ b/lighting/material/normal.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialNormal()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/normal.hlsl
+++ b/lighting/material/normal.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialNormal()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/occlusion.glsl
+++ b/lighting/material/occlusion.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialOcclusion()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/occlusion.hlsl
+++ b/lighting/material/occlusion.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material normal property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialOcclusion()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/roughness.glsl
+++ b/lighting/material/roughness.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material roughness property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material roughness property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialRoughness()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/roughness.hlsl
+++ b/lighting/material/roughness.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material roughness property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material roughness property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialRoughness()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/shininess.glsl
+++ b/lighting/material/shininess.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material shininess property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material shininess property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialShininess()
 */
 

--- a/lighting/material/shininess.hlsl
+++ b/lighting/material/shininess.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material shininess property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material shininess property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialShininess()
 */
 

--- a/lighting/material/specular.glsl
+++ b/lighting/material/specular.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material specular property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material specular property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: vec4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/specular.hlsl
+++ b/lighting/material/specular.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: get material specular property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
+description: Get material specular property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines 
 use: float4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -14,7 +14,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: <vec4> pbr( <Material> _material ) 
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -11,7 +11,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: <float4> pbr( <Material> _material ) 
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/pbrClearCoat.glsl
+++ b/lighting/pbrClearCoat.glsl
@@ -18,7 +18,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: <vec4> pbr( <Material> _material ) 
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/pbrClearCoat.hlsl
+++ b/lighting/pbrClearCoat.hlsl
@@ -13,7 +13,7 @@
 #include "common/envBRDFApprox.hlsl"
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: <float4> pbr( <Material> _material ) 
 options:
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)

--- a/lighting/pbrGlass.glsl
+++ b/lighting/pbrGlass.glsl
@@ -16,7 +16,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple glass shading model
+description: Simple glass shading model
 use: 
     - <vec4> glass(<Material> material) 
     

--- a/lighting/pbrGlass.hlsl
+++ b/lighting/pbrGlass.hlsl
@@ -12,7 +12,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple glass shading model
+description: Simple glass shading model
 use: 
     - <float4> glass(<Material> material) 
     

--- a/lighting/pbrLittle.glsl
+++ b/lighting/pbrLittle.glsl
@@ -15,7 +15,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: 
     - <vec4> pbrLittle(<Material> material) 
     - <vec4> pbrLittle(<vec4> albedo, <vec3> normal, <float> roughness, <float> metallic [, <vec3> f0] ) 

--- a/lighting/pbrLittle.hlsl
+++ b/lighting/pbrLittle.hlsl
@@ -11,7 +11,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: simple PBR shading model
+description: Simple PBR shading model
 use: 
     - <float4> pbrLittle(<Material> material) 
     - <float4> pbrLittle(<float4> albedo, <float3> normal, <float> roughness, <float> metallic [, <float3> f0] ) 

--- a/lighting/ray/cast.glsl
+++ b/lighting/ray/cast.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: cast ray by specific distance
+description: Cast ray by specific distance
 use: <vec3> rayCast(<Ray> ray, <float> dist)
 */
 

--- a/lighting/ray/direction.glsl
+++ b/lighting/ray/direction.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: set the direction (and origin in some cases) of a ray
+description: Set the direction (and origin in some cases) of a ray
 use: 
     - rayDirection(inout <Ray> ray, [<vec3> origin,] <vec2> pos, <vec2> resolution, <float> fov)
     - <Ray> rayDirection(<vec3> origin, <vec2> pos, <vec2> resolution, <float> fov) 

--- a/lighting/ray/new.glsl
+++ b/lighting/ray/new.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: creates a new Ray asigning origin and direction
+description: Creates a new Ray asigning origin and direction
 use: 
     - rayNew(inout <Ray> ray, [<vec3> origin, <vec3> direction])
     - <Ray> rayNew(<vec3> origin, [<vec3> direction])

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: raymarching template where it needs to define a vec4 raymarchMap( in vec3 pos ) 
+description: Raymarching template where it needs to define a vec4 raymarchMap( in vec3 pos ) 
 use: <vec4> raymarch(<vec3> camera, <vec2> st)
 options:
     - LIGHT_POSITION: in glslViewer is u_light

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: raymarching template where it needs to define a float4 raymarchMSap( in float3 pos ) 
+description: Raymarching template where it needs to define a float4 raymarchMSap( in float3 pos ) 
 use: <float4> raymarch(<float3> camera, <float2> st)
 options:
     - LIGHT_POSITION: in glslViewer is u_light

--- a/lighting/raymarch/ao.cuh
+++ b/lighting/raymarch/ao.cuh
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculare Ambient Occlusion
+description: Calculare Ambient Occlusion
 use: <float> raymarchAO( in <float3> pos, in <float3> nor ) 
 */
 

--- a/lighting/raymarch/ao.glsl
+++ b/lighting/raymarch/ao.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculare Ambient Occlusion
+description: Calculare Ambient Occlusion
 use: <float> raymarchAO( in <vec3> pos, in <vec3> nor ) 
 examples:
     - /shaders/lighting_raymarching.frag

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculare Ambient Occlusion
+description: Calculare Ambient Occlusion
 use: <float> raymarchAO( in <float3> pos, in <float3> nor ) 
 */
 

--- a/lighting/raymarch/camera.glsl
+++ b/lighting/raymarch/camera.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: set a camera for raymarching 
+description: Set a camera for raymarching 
 use: <mat3> raymarchCamera(in <vec3> ro, [in <vec3> ta [, in <vec3> up] ])
 examples:
     - /shaders/lighting_raymarching.frag

--- a/lighting/raymarch/camera.hlsl
+++ b/lighting/raymarch/camera.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors:  Inigo Quiles
-description: set a camera for raymarching 
+description: Set a camera for raymarching 
 use: <float3x3> raymarchCamera(in <float3> ro, [in <float3> ta [, in <float3> up] ])
 */
 

--- a/lighting/raymarch/cast.cuh
+++ b/lighting/raymarch/cast.cuh
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: cast a ray
+description: Cast a ray
 use: <float> castRay( in <float3> pos, in <float3> nor ) 
 */
 

--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: cast a ray
+description: Cast a ray
 use: <float> castRay( in <vec3> pos, in <vec3> nor ) 
 */
 

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: cast a ray
+description: Cast a ray
 use: <float> castRay( in <float3> pos, in <float3> nor ) 
 */
 

--- a/lighting/raymarch/map.cuh
+++ b/lighting/raymarch/map.cuh
@@ -1,6 +1,6 @@
 /*
 contributors:  Inigo Quiles
-description: map of SDF functions to be declare
+description: Map of SDF functions to be declare
 use: <float4> raymarchMap( in <vec3> pos ) 
 */
 

--- a/lighting/raymarch/map.glsl
+++ b/lighting/raymarch/map.glsl
@@ -1,6 +1,6 @@
 /*
 contributors:  Inigo Quiles
-description: map of SDF functions to be declare
+description: Map of SDF functions to be declare
 use: <vec4> raymarchMap( in <vec3> pos ) 
 examples:
     - /shaders/lighting_raymarching.frag

--- a/lighting/raymarch/map.hlsl
+++ b/lighting/raymarch/map.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors:  Inigo Quiles
-description: map of SDF functions to be declare
+description: Map of SDF functions to be declare
 use: <float4> raymarchMap( in <float3> pos ) 
 */
 

--- a/lighting/raymarch/normal.cuh
+++ b/lighting/raymarch/normal.cuh
@@ -4,7 +4,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
+description: Calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
 use: <float> raymarchNormal( in <float3> pos ) 
 */
 

--- a/lighting/raymarch/normal.glsl
+++ b/lighting/raymarch/normal.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
+description: Calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
 use: <float> raymarchNormal( in <vec3> pos ) 
 examples:
     - /shaders/lighting_raymarching.frag

--- a/lighting/raymarch/normal.hlsl
+++ b/lighting/raymarch/normal.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
+description: Calculate normals http://iquilezles.org/www/articles/normalsSDF/normalsSDF.htm
 use: <float> raymarchNormal( in <float3> pos ) 
 */
 

--- a/lighting/raymarch/render.glsl
+++ b/lighting/raymarch/render.glsl
@@ -7,7 +7,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: default raymarching renderer
+description: Default raymarching renderer
 use: <vec4> raymarchDefaultRender( in <vec3> ro, in <vec3> rd ) 
 options:
     - LIGHT_COLOR: vec3(0.5) or u_lightColor in GlslViewer

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -6,7 +6,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: default raymarching renderer
+description: Default raymarching renderer
 use: <float4> raymarchDefaultRender( in <float3> ro, in <float3> rd ) 
 options:
     - LIGHT_COLOR: float3(0.5) or u_lightColor in glslViewer

--- a/lighting/raymarch/softShadow.cuh
+++ b/lighting/raymarch/softShadow.cuh
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
+description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
 use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin, in <float> tmax) 
 */
 

--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
+description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
 use: <float> raymarchSoftshadow( in <vec3> ro, in <vec3> rd, in <float> tmin, in <float> tmax) 
 examples:
     - /shaders/lighting_raymarching.frag

--- a/lighting/raymarch/softShadow.hlsl
+++ b/lighting/raymarch/softShadow.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
+description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
 use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin, in <float> tmax) 
 */
 

--- a/lighting/raymarch/volume.glsl
+++ b/lighting/raymarch/volume.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: default raymarching renderer
+description: Default raymarching renderer
 use: <vec4> raymarchDefaultRender( in <vec3> ro, in <vec3> rd ) 
 options:
     - RAYMARCH_MATERIAL_FNC(RGB) vec3(RGB)

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: default raymarching renderer
+description: Default raymarching renderer
 use: <float4> raymarchDefaultRender( in  float3> ro, in  float3> rd ) 
 options:
     - RAYMARCH_MATERIAL_FNC(RGB) float3(RGB)

--- a/lighting/shadow.glsl
+++ b/lighting/shadow.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sample shadow map using PCF
+description: Sample shadow map using PCF
 use:
     - <float> sampleShadowPCF(<SAMPLER_TYPE> depths, <vec2> size, <vec2> uv, <float> compare)
     - <float> sampleShadowPCF(<vec3> lightcoord)

--- a/lighting/shadow.hlsl
+++ b/lighting/shadow.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sample shadow map using PCF
+description: Sample shadow map using PCF
 use:
     - <float> sampleShadowPCF(<SAMPLER_TYPE> depths, <float2> size, <float2> uv, <float> compare)
     - <float> sampleShadowPCF(<float3> lightcoord)

--- a/lighting/specular.glsl
+++ b/lighting/specular.glsl
@@ -7,7 +7,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate specular contribution
+description: Calculate specular contribution
 use: 
     - specular(<vec3> L, <vec3> N, <vec3> V, <float> roughness[, <float> fresnel])
     - specular(<vec3> L, <vec3> N, <vec3> V, <float> NoV, <float> NoL, <float> roughness, <float> fresnel)

--- a/lighting/specular.hlsl
+++ b/lighting/specular.hlsl
@@ -7,7 +7,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: calculate specular contribution
+description: Calculate specular contribution
 use: 
     - specular(<float3> L, <float3> N, <float3> V, <float> roughness[, <float> fresnel])
     - specular(<float3> L, <float3> N, <float3> V, <float> NoV, <float> NoL, <float> roughness, <float> fresnel)

--- a/lighting/sphereMap.glsl
+++ b/lighting/sphereMap.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: given a Spherical Map texture and a normal direction returns the right pixel
+description: Given a Spherical Map texture and a normal direction returns the right pixel
 use: spheremap(<SAMPLER_TYPE> texture, <vec3> normal)
 options:
     SPHEREMAP_EYETOPOINT: where the eye is looking

--- a/lighting/sphereMap.hlsl
+++ b/lighting/sphereMap.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: given a Spherical Map texture and a normal direction returns the right pixel
+description: Given a Spherical Map texture and a normal direction returns the right pixel
 use: spheremap(<SAMPLER_TYPE> texture, <float3> normal)
 */
 

--- a/lighting/sphericalHarmonics.glsl
+++ b/lighting/sphericalHarmonics.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: return the spherical harmonic value facing a normal direction
+description: Return the spherical harmonic value facing a normal direction
 use: sphericalHarmonics( <vec3> normal)
 options:
   SPHERICALHARMONICS_BANDS: 2 for RaspberryPi and WebGL for the rest is 3

--- a/lighting/sphericalHarmonics.hlsl
+++ b/lighting/sphericalHarmonics.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: return the spherical harmonic value facing a normal direction
+description: Return the spherical harmonic value facing a normal direction
 use: sphericalHarmonics( <float3> normal)
 options:
   SPHERICALHARMONICS_BANDS: 2 for RaspberryPi and WebGL for the rest is 3

--- a/lighting/toMetallic.glsl
+++ b/lighting/toMetallic.glsl
@@ -1,7 +1,7 @@
 #include "../math/saturate.glsl"
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert diffuse/specular/glossiness workflow to PBR metallic factor 
+description: Convert diffuse/specular/glossiness workflow to PBR metallic factor 
 use: <float> toMetallic(<vec3> diffuse, <vec3> specular, <float> maxSpecular)
 */
 

--- a/lighting/toMetallic.hlsl
+++ b/lighting/toMetallic.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convert diffuse/specular/glossiness workflow to PBR metallic factor 
+description: Convert diffuse/specular/glossiness workflow to PBR metallic factor 
 use: <float> toMetallic(<float3> diffuse, <float3> specular, <float> maxSpecular)
 */
 

--- a/lighting/toShininess.glsl
+++ b/lighting/toShininess.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convertes from PBR roughness/metallic to a shininess factor (typaclly use on diffuse/specular/ambient workflow) 
+description: Convertes from PBR roughness/metallic to a shininess factor (typaclly use on diffuse/specular/ambient workflow) 
 use: float toShininess(<float> roughness, <float> metallic)
 */
 

--- a/lighting/toShininess.hlsl
+++ b/lighting/toShininess.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: convertes from PBR roughness/metallic to a shininess factor (typaclly use on diffuse/specular/ambient workflow) 
+description: Convertes from PBR roughness/metallic to a shininess factor (typaclly use on diffuse/specular/ambient workflow) 
 use: float toShininess(<float> roughness, <float> metallic)
 */
 

--- a/lighting/wavelength.glsl
+++ b/lighting/wavelength.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: wavelength to RGB
+description: Wavelength to RGB
 use: <float3> wavelength(<float> wavelength)
 */
 


### PR DESCRIPTION
Just some minor housekeeping. Thought it would be nice if all descriptions started with a capital letter. Looks better when you browse the categories on the site.