### PR TITLE
Fix missing return statemtent for rgb2oklab.

### DIFF
--- a/color/space/rgb2oklab.glsl
+++ b/color/space/rgb2oklab.glsl
@@ -10,6 +10,6 @@ use: <vec3\vec4> rgb2oklab(<vec3|vec4> srgb)
 
 #ifndef FNC_RGB2OKLAB
 #define FNC_RGB2OKLAB
-vec3 rgb2oklab(const in vec3 rgb) { srgb2oklab( rgb2srgb(rgb) ); }
+vec3 rgb2oklab(const in vec3 rgb) { return srgb2oklab( rgb2srgb(rgb) ); }
 vec4 rgb2oklab(const in vec4 rgb) { return vec4(rgb2oklab(rgb.rgb), rgb.a); }
 #endif

--- a/color/space/rgb2oklab.hlsl
+++ b/color/space/rgb2oklab.hlsl
@@ -10,6 +10,6 @@ use: <float3\float4> rgb2oklab(<float3|float4> srgb)
 
 #ifndef FNC_RGB2OKLAB
 #define FNC_RGB2OKLAB
-float3 rgb2oklab(const in float3 rgb) { srgb2oklab( rgb2srgb(rgb) ); }
+float3 rgb2oklab(const in float3 rgb) { return srgb2oklab( rgb2srgb(rgb) ); }
 float4 rgb2oklab(const in float4 rgb) { return float4(rgb2oklab(rgb.rgb), rgb.a); }
 #endif

--- a/color/space/rgb2oklab.wgsl
+++ b/color/space/rgb2oklab.wgsl
@@ -8,4 +8,4 @@ description: |
 use: <vec3\vec4> rgb2oklab(<vec3|vec4> srgb)
 */
 
-fn rgb2oklab(rgb: vec3f) -> vec3f { srgb2oklab( rgb2srgb(rgb) ); }
+fn rgb2oklab(rgb: vec3f) -> vec3f { return srgb2oklab( rgb2srgb(rgb) ); }


### PR DESCRIPTION
I was attempting to `#include "lygia/color/space.glsl"` in the editor on lygia.xyz and got the error: 'rgb2oklab' : function does not return a value.

I noticed these functions were missing 'return' statements.