### PR TITLE
Improve color mixing for SDF smooth union and subtraction operations

### DIFF
--- a/sdf/opSubtraction.glsl
+++ b/sdf/opSubtraction.glsl
@@ -20,7 +20,9 @@ float opSubtraction( float d1, float d2, float k ) {
 
 vec4 opSubtraction( vec4 d1, vec4 d2, float k ) {
     float h = clamp( 0.5 - 0.5*(d2.a+d1.a)/k, 0.0, 1.0 );
-    return mix( d2, -d1, h ) + k*h*(1.0-h);
+    vec4 result = mix( d2, -d1, h );
+    result.a += k*h*(1.0-h);
+    return result;
 }
 
 #endif

--- a/sdf/opUnion.cuh
+++ b/sdf/opUnion.cuh
@@ -22,7 +22,9 @@ inline __host__ __device__ float opUnion( float d1, float d2, float k ) {
 
 inline __host__ __device__ float4 opUnion( float4 d1, float4 d2, float k ) {
     float h = clamp( 0.5f + 0.5f * (d2.w - d1.w)/k, 0.0f, 1.0f );
-    return mix( d2, d1, h ) - k * h * (1.0f-h); 
+    float4 result = mix( d2, d1, h ); 
+    result.w -= k * h * (1.0f-h);
+    return result;
 }
 
 #endif

--- a/sdf/opUnion.glsl
+++ b/sdf/opUnion.glsl
@@ -20,7 +20,9 @@ float opUnion( float d1, float d2, float k ) {
 
 vec4 opUnion( vec4 d1, vec4 d2, float k ) {
     float h = saturate( 0.5 + 0.5*(d2.a - d1.a)/k );
-    return mix( d2, d1, h ) - k*h*(1.0-h); 
+    vec4 result = mix(d2, d1, h);
+    result.w -= k * h * (1.0 - h);
+    return result;
 }
 
 #endif

--- a/sdf/opUnion.glsl
+++ b/sdf/opUnion.glsl
@@ -21,7 +21,7 @@ float opUnion( float d1, float d2, float k ) {
 vec4 opUnion( vec4 d1, vec4 d2, float k ) {
     float h = saturate( 0.5 + 0.5*(d2.a - d1.a)/k );
     vec4 result = mix(d2, d1, h);
-    result.w -= k * h * (1.0 - h);
+    result.a -= k * h * (1.0 - h);
     return result;
 }
 

--- a/sdf/opUnion.hlsl
+++ b/sdf/opUnion.hlsl
@@ -18,7 +18,9 @@ float opUnion( float d1, float d2, float k ) {
 
 float4 opUnion( float4 d1, float4 d2, float k ) {
     float h = saturate( 0.5 + 0.5*(d2.a - d1.a)/k );
-    return lerp( d2, d1, h ) - k*h*(1.0-h); 
+    float4 result = lerp( d2, d1, h ); 
+    result.a -= k*h*(1.0-h);
+    return result;
 }
 
 #endif


### PR DESCRIPTION
Previously, when performing union or subtraction operations with smoothing of 2 SDFs that used the same color, the operation would change the color (i.e. making it lighter for subtraction or darker for union). The amount of color variation increased as the value for the operation smoothing increased. See these screenshots for example, where the skin color should be uniform (discounting variations due to lighting):

| Small smoothing value | Larger smoothing value |
| ------------- | ------------- |
| ![image](https://github.com/patriciogonzalezvivo/lygia/assets/2722461/25f1f5a1-1bf2-4f9d-b2a2-59f222d76c78) | ![image](https://github.com/patriciogonzalezvivo/lygia/assets/2722461/398d39f8-43d4-49af-b577-0936aae6ea4a) |

Modifying the union and subtraction operation functions as in this PR seems to resolve the color mixing, and produces the expected result:

![image](https://github.com/patriciogonzalezvivo/lygia/assets/2722461/f334b244-63ae-4a3c-a289-7ebf7a66058a)
