### PR TITLE
Fixed typo bugs in hlsl versions of yiq2rgb and hsv2rgb

### DIFF
--- a/color/space/hsv2rgb.hlsl
+++ b/color/space/hsv2rgb.hlsl
@@ -8,8 +8,6 @@ use: <float3|float4> hsv2rgb(<float3|float4> hsv)
 
 #ifndef FNC_HSV2RGB
 #define FNC_HSV2RGB
-float3 hsv2rgb(in float3 hsb) {
-    return ((hue2rgb(hsb.x) - 1.0) * hsv.y + 1.0) * hsv.z;
-}
-float4 hsv2rgb(in float4 hsb) { return float4(hsv2rgb(hsb.rgb), hsb.a); }
+float3 hsv2rgb(in float3 hsv) { return ((hue2rgb(hsv.x) - 1.0) * hsv.y + 1.0) * hsv.z; }
+float4 hsv2rgb(in float4 hsv) { return float4(hsv2rgb(hsv.rgb), hsv.a); }
 #endif

--- a/color/space/yiq2rgb.hlsl
+++ b/color/space/yiq2rgb.hlsl
@@ -16,6 +16,6 @@ const float3x3 YIQ2RGB = float3x3(  1.0,  0.9469,  0.6235,
 
 #ifndef FNC_YIQ2RGB
 #define FNC_YIQ2RGB
-float3 yiq2rgb(in float3 yiq) { return mul(yiq2rgb_mat, yiq); }
+float3 yiq2rgb(in float3 yiq) { return mul(YIQ2RGB, yiq); }
 float4 yiq2rgb(in float4 yiq) { return float4(yiq2rgb(yiq.rgb), yiq.a); }
 #endif


### PR DESCRIPTION
Both functions were broken because of typos in variable names.