### PR TITLE
Fixed pbrLittle indirect diffuse.

### DIFF
--- a/lighting/pbrLittle.glsl
+++ b/lighting/pbrLittle.glsl
@@ -66,7 +66,7 @@ vec4 pbrLittle( vec4 _albedo, vec3 _position, vec3 _normal, float _roughness, fl
 
     _albedo.rgb = _albedo.rgb * diff;
 #ifdef SCENE_SH_ARRAY
-    _albedo.rgb *= tonemapReinhard( sphericalHarmonics(N) );
+    _albedo.rgb += tonemapReinhard( sphericalHarmonics(N) );
 #endif
 
     float NoV = dot(N, V); 

--- a/lighting/pbrLittle.hlsl
+++ b/lighting/pbrLittle.hlsl
@@ -72,9 +72,9 @@ float4 pbrLittle(float4 albedo, float3 position, float3 normal, float roughness,
 
     albedo.rgb = albedo.rgb * diff;
     #if defined(UNITY_COMPILER_HLSL)
-    albedo.rgb *= ShadeSH9(half4(N,1));
+    albedo.rgb += ShadeSH9(half4(N,1));
     #elif defined(SCENE_SH_ARRAY)
-    albedo.rgb *= tonemapReinhard( sphericalHarmonics(N) );
+    albedo.rgb += tonemapReinhard( sphericalHarmonics(N) );
     #endif
 
     float NoV = dot(N, V); 


### PR DESCRIPTION
Fixed lighting/pbrLittle. The indirect diffuse component (spherical harmonics) should be added to direct diffuse, not multiplied by it.

![pbr little fix](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/0f4c35d3-19dd-4843-a020-6ded4226fa91)
