### PR TITLE
Roughness-adjusted fresnel.

### DIFF
--- a/lighting/fresnel.glsl
+++ b/lighting/fresnel.glsl
@@ -1,5 +1,6 @@
 #include "common/schlick.glsl"
 
+#include "../math/pow5.hlsl"
 #include "../math/const.glsl"
 #include "../math/saturate.glsl"
 
@@ -8,6 +9,7 @@ contributors: Patricio Gonzalez Vivo
 description: Resolve fresnel coeficient
 use:
     - <float|vec3> fresnel(const <float|vec3> f0, <float> NoV)
+    - <float|vec3> fresnel(const <float|vec3> f0, <float> NoV, float roughness)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -31,6 +33,14 @@ vec3 fresnel(const in vec3 f0, const in float NoV) {
 
 float fresnel(const in float f0, const in float NoV) {
     return schlick(f0, 1.0, NoV);
+}
+
+// Roughness-adjusted fresnel function to attenuate high speculars at glancing angles
+// Very useful when used with filtered environment maps
+// See https://seblagarde.wordpress.com/2011/08/17/hello-world/
+vec3 fresnel(vec3 f0, float NoV, float roughness)
+{
+    return f0 + (max(1.0 - roughness, f0) - f0) * pow5(1.0 - NoV);
 }
 
 #endif

--- a/lighting/fresnel.hlsl
+++ b/lighting/fresnel.hlsl
@@ -1,10 +1,12 @@
 #include "common/schlick.hlsl"
+#include "../math/pow5.hlsl"
 
 /*
 contributors: Patricio Gonzalez Vivo
 description: Resolve fresnel coeficient
 use:
     - <float3> fresnel(const <float3> f0, <float> NoV)
+    - <float3> fresnel(const <float3> f0, <float> NoV, float roughness)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -33,5 +35,12 @@ float fresnel(const in float f0, const in float NoV)
     return schlick(f0, 1.0, NoV);
 }
 
+// Roughness-adjusted fresnel function to attenuate high speculars at glancing angles
+// Very useful when used with filtered environment maps
+// See https://seblagarde.wordpress.com/2011/08/17/hello-world/
+float3 fresnel(float3 f0, float NoV, float roughness)
+{
+    return f0 + (max(1.0 - roughness, f0) - f0) * pow5(1.0-NoV);
+}
 
 #endif

--- a/lighting/fresnel.hlsl
+++ b/lighting/fresnel.hlsl
@@ -1,15 +1,10 @@
 #include "common/schlick.hlsl"
 
-#include "fakeCube.hlsl"
-#include "sphericalHarmonics.hlsl"
-#include "../color/tonemap.hlsl"
-
 /*
 contributors: Patricio Gonzalez Vivo
 description: Resolve fresnel coeficient
 use:
-    - <float3> fresnel(const <float3> f0, <float> LoH)
-    - <float3> fresnel(<float3> _R, <float3> _f0, <float> _NoV)
+    - <float3> fresnel(const <float3> f0, <float> NoV)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -18,22 +13,25 @@ license:
 #ifndef FNC_FRESNEL
 #define FNC_FRESNEL
 
-float3 fresnel(const float3 f0, float LoH) {
+float3 fresnel(const in float3 f0, float3 normal, float3 view)
+{
+    return schlick(f0, 1.0, dot(view, normal));
+}
+
+float3 fresnel(const float3 f0, float NoV)
+{
 #if defined(TARGET_MOBILE) || defined(PLATFORM_RPI)
-    return schlick(f0, 1.0, LoH);
+    return schlick(f0, 1.0, NoV);
 #else
     float f90 = saturate(dot(f0, float3(50.0, 50.0, 50.0) * 0.33));
-    return schlick(f0, f90, LoH);
+    return schlick(f0, f90, NoV);
 #endif
 }
 
-// float fresnelf(float3 V, float3 N, float R0) {
-//     float cosAngle = 1.0-max(dot(V, N), 0.0);
-//     float result = cosAngle * cosAngle;
-//     result = result * result;
-//     result = result * cosAngle;
-//     result = clamp(result * (1.0 - R0) + R0, 0.0, 1.0);
-//     return result;
-// }
+float fresnel(const in float f0, const in float NoV)
+{
+    return schlick(f0, 1.0, NoV);
+}
+
 
 #endif


### PR DESCRIPTION
Added a roughness-adjusted fresnel function. This function has been described by Sébastien Lagarde and others.

The rationale is as follows: "Applying Fresnel term to prefiltered cubemap has a bad effect of always showing high specular color at edge, even for rough surface.... We approximate this “fresnel attenuation” empirically by introducing a fudge factor (taking count of gloss) in fresnel equation to get pleasant visual result"

This produces significant improvements when applied to the indirect components of a PBR shader.

![roughness fresnel](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/71408c76-7776-485c-ae53-b0babe8eb433)

For more details, see Lagarde's blog post.
https://seblagarde.wordpress.com/2011/08/17/hello-world/