### PR TITLE
Complete overhaul of the HLSL PBR shader to align with the GLSL Version.

### DIFF
--- a/lighting/camera.glsl
+++ b/lighting/camera.glsl
@@ -1,0 +1,21 @@
+/*
+contributors: Patricio Gonzalez Vivo
+description: Generic Camera Structure
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef STR_CAMERA
+#define STR_CAMERA
+struct Camera {
+    vec3 pos;
+    vec3 dir;
+
+    vec3 up;
+    vec3 side;
+
+    float invhalffov;
+    float maxdist;
+};
+#endif

--- a/lighting/camera.hlsl
+++ b/lighting/camera.hlsl
@@ -1,0 +1,21 @@
+/*
+contributors: Patricio Gonzalez Vivo
+description: Generic Camera Structure
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef STR_CAMERA
+#define STR_CAMERA
+struct Camera {
+    float3 pos;
+    float3 dir;
+
+    float3 up;
+    float3 side;
+
+    float invhalffov;
+    float maxdist;
+};
+#endif

--- a/lighting/common/envBRDFApprox.hlsl
+++ b/lighting/common/envBRDFApprox.hlsl
@@ -1,13 +1,33 @@
 #ifndef FNC_ENVBRDFAPPROX
 #define FNC_ENVBRDFAPPROX
 
-float3 envBRDFApprox(float3 _specularColor, float _NoV, float _roughness) {
-    float4 c0 = float4( -1, -0.0275, -0.572, 0.022 );
-    float4 c1 = float4( 1, 0.0425, 1.04, -0.04 );
+float2 envBRDFApprox(const in float _NoV, in float _roughness)
+{
+    const float4 c0 = float4(-1.0, -0.0275, -0.572, 0.022);
+    const float4 c1 = float4(1.0, 0.0425, 1.04, -0.04);
     float4 r = _roughness * c0 + c1;
-    float a004 = min( r.x * r.x, exp2( -9.28 * _NoV ) ) * r.x + r.y;
-    float2 AB = float2( -1.04, 1.04 ) * a004 + r.zw;
+    float a004 = min(r.x * r.x, exp2(-9.28 * _NoV)) * r.x + r.y;
+    float2 AB = float2(-1.04, 1.04) * a004 + r.zw;
+    return float2(AB.x, AB.y);
+}
+
+//https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+float3 envBRDFApprox(const in float3 _specularColor, const in float _NoV, const in float _roughness)
+{
+    float2 AB = envBRDFApprox(_NoV, _roughness);
     return _specularColor * AB.x + AB.y;
 }
+
+
+#ifdef STR_MATERIAL
+float2 envBRDFApprox(const in Material _M) {
+    return envBRDFApprox(_M.NoV, _M.roughness );
+}
+
+float3 envBRDFApprox(const in float3 _specularColor, const in Material _M) {
+    return envBRDFApprox(_specularColor, _M.NoV, _M.roughness);
+}
+
+#endif
 
 #endif

--- a/lighting/common/specularAO.hlsl
+++ b/lighting/common/specularAO.hlsl
@@ -11,4 +11,11 @@ float specularAO(float NoV, float ao, float roughness) {
     return 1.0;
 #endif
 }
+
+#ifdef STR_MATERIAL
+float specularAO(const in Material _M, const in float _ao) {
+    return specularAO(_M.NoV, _M.roughness, _ao);
+}
+#endif
+
 #endif

--- a/lighting/common/specularAO.hlsl
+++ b/lighting/common/specularAO.hlsl
@@ -4,9 +4,10 @@
 
 #ifndef FNC_SPECULARAO
 #define FNC_SPECULARAO
-float specularAO(float NoV, float ao, float roughness) {
+float specularAO(const in float _NoV, const in float _roughness, const in float _ao)
+{
 #if !defined(TARGET_MOBILE) && !defined(PLATFORM_RPI) && !defined(PLATFORM_WEBGL)
-    return saturate(pow(NoV + ao, exp2(-16.0 * roughness - 1.0)) - 1.0 + ao);
+    return saturate(pow(_NoV + _ao, exp2(-16.0 * _roughness - 1.0)) - 1.0 + _ao);
 #else
     return 1.0;
 #endif

--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -54,4 +54,10 @@ float3 envMap(float3 _normal, float _roughness, float _metallic) {
 float3 envMap(float3 _normal, float _roughness) {
     return envMap(_normal, _roughness, 1.0);
 }
+
+#ifdef STR_MATERIAL
+float3 envMap(const in Material _M) {
+    return envMap(_M.R, _M.roughness, _M.metallic);
+}
+#endif
 #endif

--- a/lighting/fresnelReflection.hlsl
+++ b/lighting/fresnelReflection.hlsl
@@ -41,4 +41,10 @@ float3 fresnelReflection(float3 R, float3 f0, float NoV) {
     return reflectColor * frsnl;
 }
 
+#ifdef STR_MATERIAL
+float3 fresnelReflection(const in Material _M) {
+    return fresnelReflection(_M.R, _M.f0, _M.NoV) * (1.0-_M.roughness);
+}
+#endif
+
 #endif

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -38,6 +38,16 @@ license:
 #define LIGHT_INTENSITY 1.0
 #endif
 
+#ifndef STR_LIGHT_DIRECTIONAL
+#define STR_LIGHT_DIRECTIONAL
+struct LightDirectional
+{
+    float3 direction;
+    float3 color;
+    float intensity;
+};
+#endif
+
 #ifndef FNC_LIGHT_DIRECTIONAL
 #define FNC_LIGHT_DIRECTIONAL
 

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -68,4 +68,49 @@ void lightDirectional(float3 _diffuseColor, float3 _specularColor, float3 _N, fl
 //     return lightDirectional(_diffuseColor, _specularColor, _N, _V, _NoV, _roughness, _f0, 1.0, _diffuse, _specular);
 // }
 
+void lightDirectional(
+    const in float3 _diffuseColor, const in float3 _specularColor,
+    const in float3 _V,
+    const in float3 _Ld, const in float3 _Lc, const in float _Li,
+    const in float3 _N, const in float _NoV, const in float _NoL,
+    const in float _roughness, const in float _f0,
+    inout float3 _diffuse, inout float3 _specular)
+{
+    float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);
+    float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
+
+    _diffuse += max(float3(0.0, 0.0, 0.0), _Li * (_diffuseColor * _Lc * dif));
+    _specular += max(float3(0.0, 0.0, 0.0), _Li * (_specularColor * _Lc * spec));
+}
+
+#ifdef STR_MATERIAL
+void lightDirectional(
+    const in float3 _diffuseColor, const in float3 _specularColor,
+    LightDirectional _L, const in Material _mat, 
+    inout float3 _diffuse, inout float3 _specular) {
+
+    float f0    = max(_mat.f0.r, max(_mat.f0.g, _mat.f0.b));
+    float NoL   = dot(_mat.normal, _L.direction);
+
+    lightDirectional(
+        _diffuseColor, _specularColor, 
+        _mat.V, 
+        _L.direction, _L.color, _L.intensity,
+        _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
+        _diffuse, _specular);
+
+#ifdef SHADING_MODEL_SUBSURFACE
+    float3  h     = normalize(_mat.V + _L.direction);
+    float NoH   = saturate(dot(_mat.normal, h));
+    float LoH   = saturate(dot(_L.direction, h));
+
+    float scatterVoH = saturate(dot(_mat.V, -_L.direction));
+    float forwardScatter = exp2(scatterVoH * _mat.subsurfacePower - _mat.subsurfacePower);
+    float backScatter = saturate(NoL * _mat.subsurfaceThickness + (1.0 - _mat.subsurfaceThickness)) * 0.5;
+    float subsurface = lerp(backScatter, 1.0, forwardScatter) * (1.0 - _mat.subsurfaceThickness);
+    _diffuse += _mat.subsurfaceColor * (subsurface * diffuseLambert());
+#endif
+}
+#endif
+
 #endif

--- a/lighting/light/new.hlsl
+++ b/lighting/light/new.hlsl
@@ -1,0 +1,80 @@
+#include "directional.hlsl"
+#include "point.hlsl"
+#include "../shadow.hlsl"
+
+#ifndef FNC_LIGHT_NEW
+#define FNC_LIGHT_NEW
+
+#if defined(LIGHT_DIRECTION) 
+void lightNew(out LightDirectional _L) {
+    #ifdef LIGHT_DIRECTION
+    _L.direction    = normalize(LIGHT_DIRECTION);
+    #elif defined(LIGHT_POSITION)
+    _L.direction    = normalize(LIGHT_POSITION);
+    #else
+    _L.direction    = normalize(float3(0.0, 1.0, -1.0));
+    #endif
+
+    #ifdef LIGHT_COLOR
+    _L.color        = LIGHT_COLOR;
+    #else 
+    _L.color        = float3(1.0, 1.0, 1.0);
+    #endif
+
+    #ifdef LIGHT_INTENSITY
+    _L.intensity    = LIGHT_INTENSITY;
+    #else
+    _L.intensity    = 1.0;
+    #endif
+    
+    #if defined(LIGHT_SHADOWMAP) && defined(LIGHT_SHADOWMAP_SIZE) && defined(LIGHT_COORD)
+    _L.intensity *= shadow(LIGHT_SHADOWMAP, float2(LIGHT_SHADOWMAP_SIZE), (LIGHT_COORD).xy, (LIGHT_COORD).z);
+    #endif
+}
+
+LightDirectional LightDirectionalNew() { LightDirectional l; lightNew(l); return l; }
+#endif
+
+#if defined(LIGHT_POSITION)
+
+void lightNew(out LightPoint _L) {
+    #if defined(SURFACE_POSITION)
+    _L.position     = LIGHT_POSITION - SURFACE_POSITION.xyz;
+    #else
+    _L.position     = LIGHT_POSITION;
+    #endif
+    
+    _L.color        = LIGHT_COLOR;
+    _L.intensity    = LIGHT_INTENSITY;
+
+    #ifdef LIGHT_COLOR
+    _L.color        = LIGHT_COLOR;
+    #else 
+    _L.color        = float3(1.0, 1.0, 1.0);
+    #endif
+
+    #ifdef LIGHT_INTENSITY
+    _L.intensity    = LIGHT_INTENSITY;
+    #else
+    _L.intensity    = 1.0;
+    #endif
+
+    #ifdef LIGHT_FALLOFF
+    _L.falloff      = LIGHT_FALLOFF;
+    #else
+    _L.falloff      = 0.0;
+    #endif
+
+    #if defined(LIGHT_SHADOWMAP) && defined(LIGHT_SHADOWMAP_SIZE) && defined(LIGHT_COORD)
+    _L.intensity *= shadow(LIGHT_SHADOWMAP, float2(LIGHT_SHADOWMAP_SIZE), (LIGHT_COORD).xy, (LIGHT_COORD).z);
+    #endif
+}
+
+LightPoint LightPointNew() {
+    LightPoint l;
+    lightNew(l);
+    return l;
+}
+#endif
+
+#endif

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -47,6 +47,17 @@ license:
 #define LIGHT_FALLOFF   0.0
 #endif
 
+#ifndef STR_LIGHT_POINT
+#define STR_LIGHT_POINT
+struct LightPoint
+{
+    float3 position;
+    float3 color;
+    float intensity;
+    float falloff;
+};
+#endif
+
 #ifndef FNC_LIGHT_POINT
 #define FNC_LIGHT_POINT
 

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -85,4 +85,57 @@ void lightPoint(float3 _diffuseColor, float3 _specularColor, float3 _N, float3 _
     lightPoint(_diffuseColor, _specularColor, _N, _V,  _NoV, _roughness, _f0, 1.0, _diffuse, _specular);
 }
 
+void lightPoint(
+    const in float3 _diffuseColor, const in float3 _specularColor,
+    const in float3 _V,
+    const in float3 _Lp, const in float3 _Ld, const in float3 _Lc, const in float _Li, const in float _Ldist, const in float _Lof,
+    const in float3 _N, const in float _NoV, const in float _NoL, const in float _roughness, const in float _f0,
+    inout float3 _diffuse, inout float3 _specular)
+{
+
+    float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness); // * INV_PI;
+    float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
+
+    float3 lightContribution = _Lc * _Li;
+    if (_Lof > 0.0)
+        lightContribution *= falloff(_Ldist, _Lof);
+
+    _diffuse += max(float3(0.0, 0.0, 0.0), _diffuseColor * lightContribution * dif);
+    _specular += max(float3(0.0, 0.0, 0.0), _specularColor * lightContribution * spec);
+}
+
+#ifdef STR_MATERIAL
+void lightPoint(
+    const in float3 _diffuseColor, const in float3 _specularColor,
+    LightPoint _L, const in Material _mat, 
+    inout float3 _diffuse, inout float3 _specular) 
+    {
+    float dist  = length(_L.position);
+    float3 L      = _L.position/dist;
+
+    float f0    = max(_mat.f0.r, max(_mat.f0.g, _mat.f0.b));
+    float NoL   = dot(_mat.normal, L);
+
+    lightPoint( _diffuseColor, _specularColor, 
+                _mat.V, 
+                _L.position, L, _L.color, _L.intensity, dist, _L.falloff, 
+                _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
+                _diffuse, _specular);
+
+    // TODO:
+    // - make sure that the shadow use a perspective projection
+#ifdef SHADING_MODEL_SUBSURFACE
+    float3  h     = normalize(_mat.V + L);
+    float NoH   = saturate(dot(_mat.normal, h));
+    float LoH   = saturate(dot(L, h));
+
+    float scatterVoH = saturate(dot(_mat.V, -L));
+    float forwardScatter = exp2(scatterVoH * _mat.subsurfacePower - _mat.subsurfacePower);
+    float backScatter = saturate(NoL * _mat.thickness + (1.0 - _mat.thickness)) * 0.5;
+    float subsurface = lerp(backScatter, 1.0, forwardScatter) * (1.0 - _mat.thickness);
+    _diffuse += _mat.subsurfaceColor * (subsurface * diffuseLambert());
+#endif
+}
+#endif
+
 #endif

--- a/lighting/light/resolve.hlsl
+++ b/lighting/light/resolve.hlsl
@@ -1,0 +1,19 @@
+#include "point.hlsl"
+#include "directional.hlsl"
+#include "../material.hlsl"
+
+#ifndef FNC_LIGHT_RESOLVE
+#define FNC_LIGHT_RESOLVE
+
+void lightResolve(float3 _diffuseColor, float3 _specularColor, Material _M, LightPoint _L, inout float3 _lightDiffuse, inout float3 _lightSpecular)
+{
+    lightPoint(_diffuseColor, _specularColor, _L, _M, _lightDiffuse, _lightSpecular);
+}
+
+
+void lightResolve(float3 _diffuseColor, float3 _specularColor, Material _M, LightDirectional _L, inout float3 _lightDiffuse, inout float3 _lightSpecular)
+{
+    lightDirectional(_diffuseColor, _specularColor, _L, _M, _lightDiffuse, _lightSpecular);
+}
+
+#endif

--- a/lighting/material.hlsl
+++ b/lighting/material.hlsl
@@ -43,7 +43,6 @@ struct Material {
     
     float3  ior;                // Index of Refraction
     float3  f0;                 // reflectance at 0 degree
-    float   thickness;          // default to 0.5
     
     float   roughness;
     float   metallic;

--- a/lighting/material.hlsl
+++ b/lighting/material.hlsl
@@ -43,7 +43,8 @@ struct Material {
     
     float3  ior;                // Index of Refraction
     float3  f0;                 // reflectance at 0 degree
-
+    float   thickness;          // default to 0.5
+    
     float   roughness;
     float   metallic;
     float   ambientOcclusion;   // default 1.0
@@ -73,5 +74,9 @@ struct Material {
     float   glossiness;
 #endif
 
+// Cache
+    float3 V;
+    float3 R;
+    float NoV;
 };
 #endif

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -102,10 +102,14 @@ void materialNew(out Material _mat) {
     #endif
 #endif
 
-    // Cloath Model
+    // Cloth Model
 #if defined(SHADING_MODEL_CLOTH)
     _mat.sheenColor         = sqrt(_mat.albedo.rgb);
 #endif
+
+    _mat.V                  = float3(0.0, 0.0, 0.0);
+    _mat.R                  = float3(0.0, 0.0, 0.0);
+    _mat.NoV                = 0;
 }
 
 Material materialNew() {

--- a/lighting/pbrClearCoat.hlsl
+++ b/lighting/pbrClearCoat.hlsl
@@ -90,7 +90,7 @@ float4 pbrClearCoat(const Material _mat) {
 //     ssao = ssao(SCENE_DEPTH, gl_FragCoord.xy*pixel, pixel, 1.);
 // #endif 
     float diffuseAO = min(_mat.ambientOcclusion, ssao);
-    float specAO = specularAO(NoV, diffuseAO, _mat.roughness);
+    float specAO = specularAO(NoV, _mat.roughness, diffuseAO);
 
     // Global Ilumination ( mage Based Lighting )
     // ------------------------


### PR DESCRIPTION
Complete overhaul of the HLSL PBR shader to align with the GLSL Version. This includes the following dependencies:
* Ported LightPoint struct to point.hlsl
* Ported LightDIrection struct to directional.hlsl
* Ported cache fields to material.hlsl
* Ported support for Material struct in point.hlsl, directional.hlsl, fresnelReflection.hlsl and envMap.hlsl
* Ported support for Material struct in specularAO and updated signature to match glsl
* Ported new.hlsl
* Ported resolve.hlsl
* Ported and updated envBRDFApprox.hlsl
* Finally ported pbr.hlsl from glsl