### PR TITLE
PBR fixes and visual tweaks.

### DIFF
--- a/lighting/light/directional.glsl
+++ b/lighting/light/directional.glsl
@@ -39,8 +39,8 @@ void lightDirectional(
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);
     float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    _diffuse  += max(vec3(0.0), _Li * (_diffuseColor * _Lc * dif));
-    _specular += max(vec3(0.0), _Li * (_specularColor * _Lc * spec));
+    _diffuse  += max(vec3(0.0), _Li * (_diffuseColor * _Lc * dif) * _NoL);
+    _specular += max(vec3(0.0), _Li * (_specularColor * _Lc * spec) * _NoL);
 }
 
 #ifdef STR_MATERIAL

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -79,8 +79,8 @@ void lightDirectional(
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);
     float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    _diffuse += max(float3(0.0, 0.0, 0.0), _Li * (_diffuseColor * _Lc * dif));
-    _specular += max(float3(0.0, 0.0, 0.0), _Li * (_specularColor * _Lc * spec));
+    _diffuse += max(float3(0.0, 0.0, 0.0), _Li * (_diffuseColor * _Lc * dif) * _NoL);
+    _specular += max(float3(0.0, 0.0, 0.0), _Li * (_specularColor * _Lc * spec) * _NoL);
 }
 
 #ifdef STR_MATERIAL

--- a/lighting/light/point.glsl
+++ b/lighting/light/point.glsl
@@ -42,7 +42,7 @@ void lightPoint(
     float dif   = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);// * INV_PI;
     float spec  = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    vec3 lightContribution = _Lc * _Li;
+    vec3 lightContribution = _Lc * _Li * _NoL;
     if (_Lof > 0.0)
         lightContribution *= falloff(_Ldist, _Lof);
 

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -96,7 +96,7 @@ void lightPoint(
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness); // * INV_PI;
     float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    float3 lightContribution = _Lc * _Li;
+    float3 lightContribution = _Lc * _Li * _NoL;
     if (_Lof > 0.0)
         lightContribution *= falloff(_Ldist, _Lof);
 

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -65,7 +65,7 @@ vec4 pbr(const in Material _mat) {
     float diffuseAO = min(M.ambientOcclusion, ssao);
 
     vec3 Fr = vec3(0.0, 0.0, 0.0);
-    Fr  = envMap(M) * E * 2.0;
+    Fr  = envMap(M) * E;
     #if !defined(PLATFORM_RPI)
     Fr  += fresnelReflection(M);
     #endif

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -8,9 +8,9 @@
 
 #ifndef LIGHT_DIRECTION
 #if defined(UNITY_COMPILER_HLSL)
-#define LIGHT_DIRECTION -_WorldSpaceLightPos0.xyz
+#define LIGHT_DIRECTION _WorldSpaceLightPos0.xyz
 #else
-#define LIGHT_DIRECTION  -float3(0.0, 10.0, -50.0)
+#define LIGHT_DIRECTION float3(0.0, 10.0, -50.0)
 #endif
 #endif
 

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -83,7 +83,7 @@ float4 pbr(const Material _mat) {
     float diffuseAO = min(M.ambientOcclusion, ssao);
     
     float3 Fr = float3(0.0, 0.0, 0.0);
-    Fr  = envMap(M) * E * 2.0;
+    Fr = envMap(M) * E;
     #if !defined(PLATFORM_RPI)
     Fr  += fresnelReflection(M);
     #endif


### PR DESCRIPTION
Some fixes and visual tweaks to the PBR shader.
I back-to-backed the HLSL version against the Unity Standard Shader and my own PBR implementation (based on the Karis UE4 variant).

1. Fixed the Unity light direction in the HLSL version. It was flipped in PR #151 (my bad!)

2. Tweaked the indirect specular component (glsl and hlsl). I'm not sure what was the rationale for the previous implementation. The new one conforms to the Brian Karis article (https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile) and in any case looks much better.
![pbr fix](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/42fad749-fa57-4017-b16e-e3b4c69ebeb2)

3. As it's currently implemented, the contribution of point and directional light (direct specular and direct diffuse) doesn't look correct to me. It is missing a multiplication by `dot(N, L)`. I added that to point and directional lights, in glsl and hlsl. Again, the new version looks much better and avoids the overblown fresnel.
![pbr light fix](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/8a4a9cb7-3b9f-420d-a46d-2b3b6068774e)
