### PR TITLE
Updated pbrClearCoat to bring it in line with the latest glsl version.

### DIFF
--- a/lighting/gooch.glsl
+++ b/lighting/gooch.glsl
@@ -77,12 +77,12 @@ vec4 gooch(const in vec4 _albedo, const in vec3 _N, const in vec3 _L, const in v
 
 vec4 gooch(const in Material _M, const in LightDirectional _L) {
     vec3 V = normalize(CAMERA_POSITION - _M.position);
-    return gooch(_M.albedo, _M.normal, _L.direction, V, _M.roughness, _L.intensity * _L.shadow);
+    return gooch(_M.albedo, _M.normal, _L.direction, V, _M.roughness, _L.intensity * _M.shadow);
 }
 
 vec4 gooch(const in Material _M, const in LightPoint _L) {
     vec3 V = normalize(CAMERA_POSITION - _M.position);
-    return gooch(_M.albedo, _M.normal, _L.direction, V, _M.roughness, _L.intensity * _L.shadow);
+    return gooch(_M.albedo, _M.normal, _L.direction, V, _M.roughness, _L.intensity * _M.shadow);
 }
 
 vec4 gooch(const in Material _M) {

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -17,27 +17,6 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
-#ifndef LIGHT_POSITION
-#if defined(UNITY_COMPILER_HLSL)
-#define LIGHT_POSITION _WorldSpaceLightPos0.xyz
-#else
-#define LIGHT_POSITION  float3(0.0, 10.0, -50.0)
-#endif
-#endif
-
-#ifndef LIGHT_COLOR
-#if defined(UNITY_COMPILER_HLSL)
-#include <UnityLightingCommon.cginc>
-#define LIGHT_COLOR     _LightColor0.rgb
-#else
-#define LIGHT_COLOR     float3(0.5, 0.5, 0.5)
-#endif
-#endif
-
-#ifndef LIGHT_INTENSITY
-#define LIGHT_INTENSITY 1.0
-#endif
-
 #ifndef STR_LIGHT_DIRECTIONAL
 #define STR_LIGHT_DIRECTIONAL
 struct LightDirectional
@@ -50,23 +29,6 @@ struct LightDirectional
 
 #ifndef FNC_LIGHT_DIRECTIONAL
 #define FNC_LIGHT_DIRECTIONAL
-
-void lightDirectional(float3 _diffuseColor, float3 _specularColor, float3 _N, float3 _V, float _NoV, float _roughness, float _f0, float _shadow, inout float3 _diffuse, inout float3 _specular) {
-    #ifdef LIGHT_DIRECTION
-    float3 s = normalize(LIGHT_DIRECTION);
-    #else 
-    float3 s = normalize(LIGHT_POSITION);
-    #endif
-    float NoL = dot(_N, s);
-    float dif = diffuseOrenNayar(s, _N, _V, _NoV, NoL, _roughness);
-    float spec = specularCookTorrance(s, _N, _V, _NoV, NoL, _roughness, _f0);
-    _diffuse += max(0.0, LIGHT_INTENSITY * (_diffuseColor * LIGHT_COLOR * dif) * _shadow);
-    _specular += max(0.0, LIGHT_INTENSITY * (_specularColor * LIGHT_COLOR * spec) * _shadow);
-}
-
-// void lightDirectional(float3 _diffuseColor, float3 _specularColor, float3 _N, float3 _V, float _NoV, float _roughness, float _f0, inout float3 _diffuse, inout float3 _specular) {
-//     return lightDirectional(_diffuseColor, _specularColor, _N, _V, _NoV, _roughness, _f0, 1.0, _diffuse, _specular);
-// }
 
 void lightDirectional(
     const in float3 _diffuseColor, const in float3 _specularColor,

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -18,35 +18,6 @@ license:
 #include "../diffuse.hlsl"
 #include "falloff.hlsl"
 
-#ifndef SURFACE_POSITION
-#define SURFACE_POSITION float(0.0, 0.0, 0.0)
-#endif
-
-#ifndef LIGHT_POSITION
-#if defined(UNITY_COMPILER_HLSL)
-#define LIGHT_POSITION _WorldSpaceLightPos0.xyz
-#else
-#define LIGHT_POSITION  float3(0.0, 10.0, -50.0)
-#endif
-#endif
-
-#ifndef LIGHT_COLOR
-#if defined(UNITY_COMPILER_HLSL)
-#include <UnityLightingCommon.cginc>
-#define LIGHT_COLOR     _LightColor0.rgb
-#else
-#define LIGHT_COLOR     float3(0.5, 0.5, 0.5)
-#endif
-#endif
-
-#ifndef LIGHT_INTENSITY
-#define LIGHT_INTENSITY 1.0
-#endif
-
-#ifndef LIGHT_FALLOFF
-#define LIGHT_FALLOFF   0.0
-#endif
-
 #ifndef STR_LIGHT_POINT
 #define STR_LIGHT_POINT
 struct LightPoint
@@ -60,30 +31,6 @@ struct LightPoint
 
 #ifndef FNC_LIGHT_POINT
 #define FNC_LIGHT_POINT
-
-void lightPoint(float3 _diffuseColor, float3 _specularColor, float3 _N, float3 _V, float _NoV, float _roughness, float _f0, float _shadow, inout float3 _diffuse, inout float3 _specular) {
-    float3 toLight = LIGHT_POSITION - (SURFACE_POSITION).xyz;
-    float toLightLength = length(toLight);
-    float3 s = toLight/toLightLength;
-
-    float NoL = dot(_N, s);
-
-    float dif = diffuse(s, _N, _V, _NoV, NoL, _roughness);// * INV_PI;
-    float spec = specular(s, _N, _V, _NoV, NoL, _roughness, _f0);
-
-    float3 lightContribution = LIGHT_COLOR * LIGHT_INTENSITY * _shadow;
-    #ifdef LIGHT_FALLOFF
-    if (LIGHT_FALLOFF > 0.0)
-        lightContribution *= falloff(toLightLength, LIGHT_FALLOFF);
-    #endif
-
-    _diffuse +=  _diffuseColor * lightContribution * dif;
-    _specular += _specularColor * lightContribution * spec;
-}
-
-void lightPoint(float3 _diffuseColor, float3 _specularColor, float3 _N, float3 _V, float _NoV, float _roughness, float _f0, inout float3 _diffuse, inout float3 _specular) {
-    lightPoint(_diffuseColor, _specularColor, _N, _V,  _NoV, _roughness, _f0, 1.0, _diffuse, _specular);
-}
 
 void lightPoint(
     const in float3 _diffuseColor, const in float3 _specularColor,

--- a/lighting/pbrClearCoat.glsl
+++ b/lighting/pbrClearCoat.glsl
@@ -175,9 +175,9 @@ vec4 pbrClearCoat(const Material _mat) {
         // If the material has a normal map, we want to use the geometric normal
         // instead to avoid applying the normal map details to the clear coat layer
         float clearCoatNoL = saturate(dot(clearCoatNormal, L.direction));
-        color.rgb = color.rgb * atten * NoL + (clearCoat * clearCoatNoL * L.color) * L.intensity * L.shadow;
+        color.rgb = color.rgb * atten * NoL + (clearCoat * clearCoatNoL * L.color) * L.intensity * _mat.shadow;
         #else
-        color.rgb = color.rgb * atten + (clearCoat * L.color) * (L.intensity * L.shadow * NoL);
+        color.rgb = color.rgb * atten + (clearCoat * L.color) * (L.intensity * _mat.shadow * NoL);
         #endif
 
         #endif

--- a/lighting/pbrClearCoat.glsl
+++ b/lighting/pbrClearCoat.glsl
@@ -98,7 +98,7 @@ vec4 pbrClearCoat(const Material _mat) {
     float specAO = specularAO(M, diffAO);
 
     vec3 Fr = vec3(0.0, 0.0, 0.0);
-    Fr = envMap(M) * E * 2.0;
+    Fr = envMap(M) * E;
     #if !defined(PLATFORM_RPI)
     Fr  += fresnelReflection(M);
     #endif

--- a/lighting/pbrClearCoat.hlsl
+++ b/lighting/pbrClearCoat.hlsl
@@ -107,7 +107,7 @@ float4 pbrClearCoat(const Material _mat)
     float specAO = specularAO(M, diffAO);
 
     float3 Fr = float3(0.0, 0.0, 0.0);
-    Fr = envMap(M) * E * 2.0;
+    Fr = envMap(M) * E;
 #if !defined(PLATFORM_RPI)
     Fr += fresnelReflection(M);
 #endif


### PR DESCRIPTION
* Straightforward port of pbrClearCoat.hlsl from glsl version
* Applied fix to specular indirect from #152  to pbrClearCoat (GLSL and HLSL versions)
* Cleaned-up obsolete functions in point.hlsl and directional.hlsl.