### PR TITLE
envMap automatic MIP level (HLSL Only)

### DIFF
--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -22,11 +22,11 @@ license:
 */
 
 #ifndef SAMPLE_CUBE_FNC
-// #define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) texCUBE(CUBEMAP, NORM)
-#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) texCUBElod(CUBEMAP, float4(NORM, LOD) )
+//#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) texCUBElod(CUBEMAP, float4(NORM, LOD) )
+#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) CUBEMAP.SampleLevel(sampler##CUBEMAP, NORM, LOD)
 #endif
 
-#ifndef ENVMAP_MAX_MIP_LEVEL
+#if defined(ENVMAP_MAX_MIP_LEVEL) && !defined(UNITY_COMPILER_HLSL)
 #define ENVMAP_MAX_MIP_LEVEL 3.0
 #endif
 
@@ -39,6 +39,12 @@ float3 envMap(float3 _normal, float _roughness, float _metallic) {
     return ENVMAP_FNC(_normal, _roughness, _metallic);
 
 // Cubemap sampling
+#elif defined(SCENE_CUBEMAP) && !defined(ENVMAP_MAX_MIP_LEVEL)
+    uint width, height, levels;
+    SCENE_CUBEMAP.GetDimensions(0, width, height, levels);
+    float lod = levels * _roughness;
+    return SAMPLE_CUBE_FNC( SCENE_CUBEMAP, _normal, lod).rgb;
+    
 #elif defined(SCENE_CUBEMAP)
     float lod = ENVMAP_MAX_MIP_LEVEL * _roughness;
     return SAMPLE_CUBE_FNC( SCENE_CUBEMAP, _normal, lod).rgb;

--- a/lighting/fresnelReflection.hlsl
+++ b/lighting/fresnelReflection.hlsl
@@ -29,7 +29,7 @@ float3 fresnelReflection(float3 R, float3 f0, float NoV) {
     reflectColor = ENVMAP_FNC(R, 0.001, 0.001);
     
     #elif defined(SCENE_CUBEMAP)
-    reflectColor = SAMPLE_CUBE_FNC( SCENE_CUBEMAP, R, ENVMAP_MAX_MIP_LEVEL).rgb;
+    reflectColor = envMap( R, 1.0 ).rgb;
 
     #elif defined(SCENE_SH_ARRAY)
     reflectColor = sphericalHarmonics(R);


### PR DESCRIPTION
Changed the envMap cubmap texture type declaration from the obsolete DirectX 9 (2002) syntax to the newer DirectX 11 (2009) syntax.

This requires clients to update the cubemap declaration on their end from
`samplerCUBE _Cube;`
to
`TextureCube _Cube;`
`SamplerState sampler_Cube;`

This allows us to query the TextureCube object for the max Mip Level.

Currently Lygia assumes a default ENVMAP_MAX_MIP_LEVEL of 3, which is:
1. Dependent on the resolution of the texture
2. Very low for typical 2k cubemap textures.

This results in cubemaps not being sufficiently blurred when using rough materials.
The new system is resolution independent and guarantees correct blurring levels.

ENVMAP_MAX_MIP_LEVEL can still be used to override the automatic setting if desired.

![mip level](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/441fcff7-5f89-4505-ae3c-cf5fabf3d155)