### PR TITLE
fcos(x): band-limited cos(x), GLSL and HLSL

### DIFF
--- a/math/fcos.glsl
+++ b/math/fcos.glsl
@@ -9,8 +9,7 @@ use: fcos(<float> value)
 #ifndef FNC_FCOS
 #define FNC_FCOS
 
-float fcos(in float x)
-{
+float fcos(in float x){
     float w = fwidth(x);
     return cos(x) * smoothstep( TWO_PI, 0.0, w );
 }

--- a/math/fcos.glsl
+++ b/math/fcos.glsl
@@ -1,0 +1,18 @@
+#include "const.glsl"
+
+/*
+contributors: Inigo Quiles
+description: A band-limited variant of cos(x) which reduces aliasing at high frequencies. From https://iquilezles.org/articles/bandlimiting/
+use: fcos(<float> value)
+*/
+
+#ifndef FNC_FCOS
+#define FNC_FCOS
+
+float fcos(in float x)
+{
+    float w = fwidth(x);
+    return cos(x) * smoothstep( TWO_PI, 0.0, w );
+}
+
+#endif

--- a/math/fcos.hlsl
+++ b/math/fcos.hlsl
@@ -1,0 +1,18 @@
+#include "const.hlsl"
+
+/*
+contributors: Inigo Quiles
+description: A band-limited variant of cos(x) which reduces aliasing at high frequencies. From https://iquilezles.org/articles/bandlimiting/
+use: fcos(<float> value)
+*/
+
+#ifndef FNC_FCOS
+#define FNC_FCOS
+
+float fcos(in float x)
+{
+    float w = fwidth(x);
+    return cos(x) * smoothstep( TWO_PI, 0.0, w );
+}
+
+#endif

--- a/math/fcos.hlsl
+++ b/math/fcos.hlsl
@@ -9,8 +9,7 @@ use: fcos(<float> value)
 #ifndef FNC_FCOS
 #define FNC_FCOS
 
-float fcos(in float x)
-{
+float fcos(in float x){
     float w = fwidth(x);
     return cos(x) * smoothstep( TWO_PI, 0.0, w );
 }


### PR DESCRIPTION
Added IQ's band-limited variant of `cos(x)` which dramatically reduces aliasing at high frequencies.
Copied as is from Inigo's 2020 article https://iquilezles.org/articles/bandlimiting/

`cos(x)` wave aliasing at high frequencies
![Screenshot 2024-07-07 140402](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/3da7435a-c536-4922-8e6c-d78f5a493422)

`fcos(x)` replacement
![Screenshot 2024-07-07 140947](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/465a7806-1d9b-4935-af94-bb26dfcff93a)
