### PR TITLE
Band-limited aafract (GLSL and HLSL)

### DIFF
--- a/math/aafract.hlsl
+++ b/math/aafract.hlsl
@@ -1,10 +1,8 @@
-#include "map.hlsl"
-
 /*
-contributors: dahart (https://www.shadertoy.com/user/dahart)
+contributors: Fabrice Neyret
 description: |
-    Anti-aliasing fract function. It clamp except for a 2-pixel wide gradient along the edge
-    Based on this example https://www.shadertoy.com/view/4l2BRD
+    Anti-aliasing fract function, including Shannon-Nyquiest filtering for high frequencies.
+    Based on this example https://www.shadertoy.com/view/3tSGWy
 use: <float> aafract(<float> x)
 option:
     AA_EDGE: in the absence of derivatives you can specify the antialiasing factor
@@ -13,17 +11,31 @@ option:
 #ifndef FNC_AAFRACT
 #define FNC_AAFRACT
 
+#ifndef NYQUIST_FNC
+#define NYQUIST_BIAS -.0  // < 0: prefer a bit of aliasing to blur 
+#define NYQUIST_SPREAD 1. // < 1: transition more brutal 
+// w = pixel width = grad(continous signal) . c = possibly fracted signal.
+#define NYQUIST_FNC(w,c) lerp(.5, c, clamp((.5-NYQUIST_BIAS-(w))/.25/NYQUIST_SPREAD,0.,1.) )
+#endif
+
 float aafract(float x) {
 #if defined(AA_EDGE)
-    float afwidth = AA_EDGE;
+    float v = frac(x),
+          w = AA_EDGE,      // pixel width. NB: x must not be discontinuous or factor discont out
+          c = v < 1.-w ? v/(1.-w) : (1.-v)/w; // replace right step by down slope (-> chainsaw is continuous).
+               // shortened slope : added downslope near v=1 
+    return NYQUIST_FNC(w,c);
 #else 
-    float afwidth = 2.0 * fwidth(x);
+    float v = frac(x),
+          w = length(float2(ddx(x), ddy(x))), // pixel width. NB: x must not be discontinuous or factor discont out
+          c = v < 1. - w ? v / (1. - w) : (1. - v) / w; // replace right step by down slope (-> chainsaw is continuous).
+               // shortened slope : added downslope near v=1 
+    return NYQUIST_FNC(w, c);
 #endif
-    float fx = frac(x);
-    float idx = 1. - afwidth;
-    return (fx < idx) ? fx : map(fx, idx, 1., fx, 0.);
 }
 
-float2 aafract(float2 v) { return float2(aafract(v.x), aafract(v.y)); }
+float2 aafract(float2 v) {
+    return float2(aafract(v.x), aafract(v.y));
+}
 
 #endif


### PR DESCRIPTION
Replaced the existing aafract with Frabrice Neyret's band-limited implementation, which deals much better with aliasing at high frequencies. This is a straightforward implementation and port of this algorithm: https://www.shadertoy.com/view/3tSGWy

Previous implementation
![Screenshot 2024-07-07 223623](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/fd1b0ea2-c820-49df-aac3-229fcb01b5fb)

Proposed implementation
![Screenshot 2024-07-07 223648](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/607ecb4d-a853-4d6c-8b69-5c7ba57484a3)
