### PR TITLE
Added more missing static keywords (HLSL only).

### DIFF
--- a/color/dither/blueNoise.hlsl
+++ b/color/dither/blueNoise.hlsl
@@ -38,7 +38,7 @@ float remap_pdf_tri_unity( float v ) {
     return 0.5 + 0.5*v;
 }
 
-const float2 blueNoiseTexturePixel = 1.0/BLUENOISE_TEXTURE_RESOLUTION;
+static const float2 blueNoiseTexturePixel = 1.0/BLUENOISE_TEXTURE_RESOLUTION;
 
 float ditherBlueNoise(SAMPLER_TYPE tex, in float b, float2 fragcoord, const in float time) {
     #ifdef DITHER_BLUENOISE_ANIMATED 

--- a/color/lut.hlsl
+++ b/color/lut.hlsl
@@ -42,9 +42,9 @@ float4 lut(in SAMPLER_TYPE tex, in float4 color, in int offset) {
 
 #else
 // Data about how the LUTs rows are encoded
-const float LUT_WIDTH = LUT_CELL_SIZE*LUT_CELL_SIZE;
-const float LUT_OFFSET = 1./ float( LUT_N_ROWS);
-const float4 LUT_SIZE = float4(LUT_WIDTH, LUT_CELL_SIZE, 1./LUT_WIDTH, 1./LUT_CELL_SIZE);
+static const float LUT_WIDTH = LUT_CELL_SIZE*LUT_CELL_SIZE;
+static const float LUT_OFFSET = 1./ float( LUT_N_ROWS);
+static const float4 LUT_SIZE = float4(LUT_WIDTH, LUT_CELL_SIZE, 1./LUT_WIDTH, 1./LUT_CELL_SIZE);
 
 // Apply LUT to a COLOR
 // ------------------------------------------------------------

--- a/color/space/rgb2xyz.hlsl
+++ b/color/space/rgb2xyz.hlsl
@@ -10,12 +10,12 @@ license:
 #ifndef RGB2XYZ_MAT
 #define RGB2XYZ_MAT
 #ifdef CIE_D50
-const float3x2 RGB2XYZ = float3x2(  
+static const float3x2 RGB2XYZ = float3x2(  
     0.4360747, 0.2225045, 0.0139322,
     0.3850649, 0.7168786, 0.0971045,
     0.1430804, 0.0606169, 0.7141733);
 #else
-const float3x2 RGB2XYZ = float3x2(  
+static const float3x2 RGB2XYZ = float3x2(  
     0.4124564, 0.2126729, 0.0193339,
     0.3575761, 0.7151522, 0.1191920,
     0.1804375, 0.0721750, 0.9503041);

--- a/math/pack.hlsl
+++ b/math/pack.hlsl
@@ -7,11 +7,11 @@ use: <float4> pack(<float> v)
 
 #ifndef CONST_PACKING
 #define CONST_PACKING
-const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
-const float UnpackDownscale = 255. / 256.; // 0..1 -> fraction (excluding 1)
-const float3 PackFactors = float3( 256. * 256. * 256., 256. * 256.,  256. );
-const float4 UnpackFactors = UnpackDownscale / float4( PackFactors, 1. );
-const float ShiftRight8 = 1. / 256.;
+static const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
+static const float UnpackDownscale = 255. / 256.; // 0..1 -> fraction (excluding 1)
+static const float3 PackFactors = float3( 256. * 256. * 256., 256. * 256.,  256. );
+static const float4 UnpackFactors = UnpackDownscale / float4( PackFactors, 1. );
+static const float ShiftRight8 = 1. / 256.;
 #endif
 
 #ifndef FNC_PACK

--- a/math/unpack.hlsl
+++ b/math/unpack.hlsl
@@ -14,11 +14,11 @@ license:
 // https://github.com/mrdoob/three.js/blob/acdda10d5896aa10abdf33e971951dbf7bd8f074/src/renderers/shaders/ShaderChunk/packing.glsl
 #ifndef CONST_PACKING
 #define CONST_PACKING
-const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
-const float UnpackDownscale = 255. / 256.; // 0..1 -> fraction (excluding 1)
-const float3 PackFactors = float3( 256. * 256. * 256., 256. * 256.,  256. );
-const float4 UnpackFactors = UnpackDownscale / float4( PackFactors, 1. );
-const float ShiftRight8 = 1. / 256.;
+static const float PackUpscale = 256. / 255.; // fraction -> 0..1 (including 1)
+static const float UnpackDownscale = 255. / 256.; // 0..1 -> fraction (excluding 1)
+static const float3 PackFactors = float3( 256. * 256. * 256., 256. * 256.,  256. );
+static const float4 UnpackFactors = UnpackDownscale / float4( PackFactors, 1. );
+static const float ShiftRight8 = 1. / 256.;
 #endif
 
 #ifndef FNC_UNPACK


### PR DESCRIPTION
The sequel to #157 All `const` variables are now `static const`, preventing them from being discarded by the HLSL compiler.