### PR TITLE
Band-limited aafract (2nd approach)

### DIFF
--- a/math/aafract.glsl
+++ b/math/aafract.glsl
@@ -1,4 +1,4 @@
-#include "map.glsl"
+#include "nyquist.glsl"
 
 /*
 contributors: dahart (https://www.shadertoy.com/user/dahart)
@@ -22,12 +22,14 @@ float aafract(float x) {
     float afwidth = 2.0 * length(vec2(dFdx(x), dFdy(x)));
     float fx = fract(x);
     float idx = 1. - afwidth;
-    return (fx < idx) ? fx : map(fx, idx, 1., fx, 0.);
+    float v = (fx < idx) ? fx/idx : (1.0-fx)/afwidth;
+    return nyquist(v, afwidth);
 #elif defined(AA_EDGE)
     float afwidth = AA_EDGE;
     float fx = fract(x);
     float idx = 1. - afwidth;
-    return (fx < idx) ? fx : map(fx, idx, 1., fx, 0.);
+    float v = (fx < idx) ? fx/idx : (1.0-fx)/afwidth;
+    return nyquist(v, afwidth);
 #else 
     return fract(x);
 #endif

--- a/math/aafract.hlsl
+++ b/math/aafract.hlsl
@@ -1,4 +1,4 @@
-#include "map.hlsl"
+#include "nyquist.hlsl"
 
 /*
 contributors: dahart (https://www.shadertoy.com/user/dahart)
@@ -17,11 +17,12 @@ float aafract(float x) {
 #if defined(AA_EDGE)
     float afwidth = AA_EDGE;
 #else 
-    float afwidth = 2.0 * fwidth(x);
+    float afwidth = 2.0 * length(float2(ddx(x), ddy(x)));
 #endif
     float fx = frac(x);
     float idx = 1. - afwidth;
-    return (fx < idx) ? fx : map(fx, idx, 1., fx, 0.);
+    float v = (fx < idx) ? fx/idx : (1.0-fx)/afwidth;
+    return nyquist(v, afwidth);
 }
 
 float2 aafract(float2 v) { return float2(aafract(v.x), aafract(v.y)); }

--- a/math/nyquist.glsl
+++ b/math/nyquist.glsl
@@ -1,0 +1,26 @@
+/*
+contributors: Shadi El Hajj
+description: A simple low-pass filter which attenuates high-frequencies.
+use: nyquist(<float> value, <float> fwidth)
+use: nyquist(<float> value, <float> width, <float> strength)
+*/
+
+#ifndef FNC_NYQUIST
+#define FNC_NYQUIST
+
+#ifndef NYQUIST_FILTER_CENTER
+#define NYQUIST_FILTER_CENTER 0.5
+#endif
+
+#ifndef NYQUIST_FILTER_WIDTH
+#define NYQUIST_FILTER_WIDTH 0.25
+#endif
+
+float nyquist(float x, float width){
+    float cutoffStart = NYQUIST_FILTER_CENTER - NYQUIST_FILTER_WIDTH;
+    float cutoffEnd = NYQUIST_FILTER_CENTER + NYQUIST_FILTER_WIDTH;
+    float f = smoothstep(cutoffEnd, cutoffStart, width);
+    return mix(0.5, x, f);
+}
+
+#endif

--- a/math/nyquist.hlsl
+++ b/math/nyquist.hlsl
@@ -1,0 +1,26 @@
+/*
+contributors: Shadi El Hajj
+description: A simple low-pass filter which attenuates high-frequencies.
+use: nyquist(<float> value, <float> fwidth)
+use: nyquist(<float> value, <float> width, <float> strength)
+*/
+
+#ifndef FNC_NYQUIST
+#define FNC_NYQUIST
+
+#ifndef NYQUIST_FILTER_CENTER
+#define NYQUIST_FILTER_CENTER 0.5
+#endif
+
+#ifndef NYQUIST_FILTER_WIDTH
+#define NYQUIST_FILTER_WIDTH 0.25
+#endif
+
+float nyquist(float x, float width){
+    float cutoffStart = NYQUIST_FILTER_CENTER - NYQUIST_FILTER_WIDTH;
+    float cutoffEnd = NYQUIST_FILTER_CENTER + NYQUIST_FILTER_WIDTH;
+    float f = smoothstep(cutoffEnd, cutoffStart, width);
+    return lerp(0.5, x, f);
+}
+
+#endif


### PR DESCRIPTION
Another take at band-limiting aafract with a slightly different approach. This time I kept the existing algorithm but tacked a low-pass filter to it, centered on the Nyquist frequency (half a pixel).

Summary of changes:
* Added nyquist.glsl and nyquist.hlsl (low-pass filters)
* Calling nyquist() in aafract (+some refactoring of the unnecessary map() call)
* Using the L2 norm instead of L1 (width) in aafract.hlsl, in line with aafract.glsl

Without band-limiting:
![Screenshot 2024-07-07 223623](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/adef2b38-628b-4043-830b-618c29b8e2e6)

With bandlimiting:
![Screenshot 2024-07-09 195048](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/7c2dad86-92c7-4355-971c-4053022ad89c)
