### PR TITLE
Anti-aliased triangle wave (GLSL and HLSL)

### DIFF
--- a/math/aamirror.glsl
+++ b/math/aamirror.glsl
@@ -1,0 +1,23 @@
+#include "nyquist.glsl"
+
+/*
+contributors: Shadi El Hajj
+description: An anti-aliased triangle wave function.
+use: <float> mirror(<float> x)
+*/
+
+#ifndef FNC_AAMIRROR
+#define FNC_AAMIRROR
+
+float aamirror(float x) {
+#if defined(AA_EDGE)
+    float afwidth = AA_EDGE;
+#else 
+    float afwidth = length(vec2(dFdx(x),dFdy(x)));
+#endif
+    float v = abs(x - floor(x + 0.5)) * 2.0;
+    return nyquist(v, afwidth);
+}
+
+#endif
+

--- a/math/aamirror.hlsl
+++ b/math/aamirror.hlsl
@@ -1,0 +1,23 @@
+#include "nyquist.hlsl"
+
+/*
+contributors: Shadi El Hajj
+description: An anti-aliased triangle wave function.
+use: <float> mirror(<float> x)
+*/
+
+#ifndef FNC_AAMIRROR
+#define FNC_AAMIRROR
+
+float aamirror(float x) {
+#if defined(AA_EDGE)
+    float afwidth = AA_EDGE;
+#else 
+    float afwidth = length(float2(ddx(x),ddy(x)));
+#endif
+    float v = abs(x - floor(x + 0.5)) * 2.0;
+    return nyquist(v, afwidth);
+}
+
+#endif
+


### PR DESCRIPTION
In the spirit of previous improvements to aafract, I added an anti-aliased and band-limited variant of math/mirror. Since this is a full rethink and rewrite of the function, and to emphasize the antialiased nature of the function and similarity to aafract and co., I named it aamirror.

math/mirror
![Screenshot 2024-07-10 223603](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/363a0c14-ec2f-49a9-8cc8-ade044f5f4ac)

math/aamirror
![Screenshot 2024-07-10 223720](https://github.com/patriciogonzalezvivo/lygia/assets/1876198/83162791-f9fc-4cdf-a76a-f5f2e56781bd)
