### PR TITLE
Moar Noise, plz!

### DIFF
--- a/generative/worley.glsl
+++ b/generative/worley.glsl
@@ -21,38 +21,72 @@ license:
 #define WORLEY_DIST_FNC distEuclidean
 #endif
 
-float worley(vec2 p){
+vec2 worley(vec2 p){
     vec2 n = floor( p );
     vec2 f = fract( p );
 
-    float dis = 1.0;
-    for( int j= -1; j <= 1; j++ )
+    float distF1 = 1.0;
+    float distF2 = 1.0;
+    vec2 off1, pos1;
+    vec2 off2, pos2;
+    for( int j= -1; j <= 1; j++ ) {
         for( int i=-1; i <= 1; i++ ) {	
-                vec2  g = vec2(i,j);
-                vec2  o = random2( n + g );
-                vec2  delta = g + o - f;
-                float d = WORLEY_DIST_FNC(g+o, f);
-                dis = min(dis,d);
+            vec2  g = vec2(i,j);
+            vec2  o = random2( n + g );
+            vec2  point = g + o;
+            float d = WORLEY_DIST_FNC(point, f);
+            if (d < distF1) {
+                distF2 = distF1;
+                distF1 = d;
+                off2 = off1;
+                off1 = g;
+                pos2 = pos1;
+                pos1 = point;
+            }
+            else if (d < distF2) {
+                distF2 = d;
+                off2 = g;
+                pos2 = point;
+            }
+        }
     }
 
-    return 1.0-dis;
+    return vec2(distF1, distF2);
 }
 
-float worley(vec3 p) {
+vec2 worley(vec3 p) {
     vec3 n = floor( p );
     vec3 f = fract( p );
 
-    float dis = 1.0;
-    for( int k = -1; k <= 1; k++ )
-        for( int j= -1; j <= 1; j++ )
+    float distF1 = 1.0;
+    float distF2 = 1.0;
+    vec3 off1, pos1;
+    vec3 off2, pos2;
+    for( int k = -1; k <= 1; k++ ) {
+        for( int j= -1; j <= 1; j++ ) {
             for( int i=-1; i <= 1; i++ ) {	
                 vec3  g = vec3(i,j,k);
                 vec3  o = random3( n + g );
-                float d = WORLEY_DIST_FNC(g+o, f);
-                dis = min(dis,d);
+                vec3  point = g + o;
+                float d = WORLEY_DIST_FNC(point, f);
+                if (d < distF1) {
+                    distF2 = distF1;
+                    distF1 = d;
+                    off2 = off1;
+                    off1 = g;
+                    pos2 = pos1;
+                    pos1 = point;
+                }
+                else if (d < distF2) {
+                    distF2 = d;
+                    off2 = g;
+                    pos2 = point;
+                }
+            }
+        }
     }
 
-    return 1.0-dis;
+    return vec2(distF1, distF2);
 }
 
 #endif

--- a/generative/worley.glsl
+++ b/generative/worley.glsl
@@ -3,8 +3,8 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Worley noise
-use: <vec2> worley(<vec2|vec3> pos)
+description: Worley noise. Returns vec2(F1, F2)
+use: <vec2> worley2(<vec2|vec3> pos)
 options:
     - WORLEY_JITTER: amount of pattern randomness. With 1.0 being the default and 0.0 resulting in a perfectly symmetrical pattern.
     - WORLEY_DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski

--- a/generative/worley.glsl
+++ b/generative/worley.glsl
@@ -6,7 +6,8 @@ contributors: Patricio Gonzalez Vivo
 description: Worley noise
 use: <vec2> worley(<vec2|vec3> pos)
 options:
-    - DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski
+    - WORLEY_JITTER: amount of pattern randomness. With 1.0 being the default and 0.0 resulting in a perfectly symmetrical pattern.
+    - WORLEY_DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski
 examples:
     - /shaders/generative_worley.frag
 license:
@@ -16,6 +17,10 @@ license:
 
 #ifndef FNC_WORLEY
 #define FNC_WORLEY
+
+#ifndef WORLEY_JITTER
+#define WORLEY_JITTER 1.0
+#endif
 
 #ifndef WORLEY_DIST_FNC
 #define WORLEY_DIST_FNC distEuclidean
@@ -32,7 +37,7 @@ vec2 worley(vec2 p){
     for( int j= -1; j <= 1; j++ ) {
         for( int i=-1; i <= 1; i++ ) {	
             vec2  g = vec2(i,j);
-            vec2  o = random2( n + g );
+            vec2  o = random2( n + g ) * WORLEY_JITTER;
             vec2  p = g + o;
             float d = WORLEY_DIST_FNC(p, f);
             if (d < distF1) {
@@ -66,7 +71,7 @@ vec2 worley(vec3 p) {
         for( int j= -1; j <= 1; j++ ) {
             for( int i=-1; i <= 1; i++ ) {	
                 vec3  g = vec3(i,j,k);
-                vec3  o = random3( n + g );
+                vec3  o = random3( n + g ) * WORLEY_JITTER;
                 vec3  p = g + o;
                 float d = WORLEY_DIST_FNC(p, f);
                 if (d < distF1) {

--- a/generative/worley.glsl
+++ b/generative/worley.glsl
@@ -33,20 +33,20 @@ vec2 worley(vec2 p){
         for( int i=-1; i <= 1; i++ ) {	
             vec2  g = vec2(i,j);
             vec2  o = random2( n + g );
-            vec2  point = g + o;
-            float d = WORLEY_DIST_FNC(point, f);
+            vec2  p = g + o;
+            float d = WORLEY_DIST_FNC(p, f);
             if (d < distF1) {
                 distF2 = distF1;
                 distF1 = d;
                 off2 = off1;
                 off1 = g;
                 pos2 = pos1;
-                pos1 = point;
+                pos1 = p;
             }
             else if (d < distF2) {
                 distF2 = d;
                 off2 = g;
-                pos2 = point;
+                pos2 = p;
             }
         }
     }
@@ -67,20 +67,20 @@ vec2 worley(vec3 p) {
             for( int i=-1; i <= 1; i++ ) {	
                 vec3  g = vec3(i,j,k);
                 vec3  o = random3( n + g );
-                vec3  point = g + o;
-                float d = WORLEY_DIST_FNC(point, f);
+                vec3  p = g + o;
+                float d = WORLEY_DIST_FNC(p, f);
                 if (d < distF1) {
                     distF2 = distF1;
                     distF1 = d;
                     off2 = off1;
                     off1 = g;
                     pos2 = pos1;
-                    pos1 = point;
+                    pos1 = p;
                 }
                 else if (d < distF2) {
                     distF2 = d;
                     off2 = g;
-                    pos2 = point;
+                    pos2 = p;
                 }
             }
         }

--- a/generative/worley.glsl
+++ b/generative/worley.glsl
@@ -26,7 +26,7 @@ license:
 #define WORLEY_DIST_FNC distEuclidean
 #endif
 
-vec2 worley(vec2 p){
+vec2 worley2(vec2 p){
     vec2 n = floor( p );
     vec2 f = fract( p );
 
@@ -59,7 +59,11 @@ vec2 worley(vec2 p){
     return vec2(distF1, distF2);
 }
 
-vec2 worley(vec3 p) {
+float worley(vec2 p){
+    return 1.0-worley2(p).x;
+}
+
+vec2 worley2(vec3 p) {
     vec3 n = floor( p );
     vec3 f = fract( p );
 
@@ -92,6 +96,10 @@ vec2 worley(vec3 p) {
     }
 
     return vec2(distF1, distF2);
+}
+
+float worley(vec3 p){
+    return 1.0-worley2(p).x;
 }
 
 #endif

--- a/generative/worley.hlsl
+++ b/generative/worley.hlsl
@@ -7,6 +7,8 @@ description: Worley noise
 use: <float2> worley(<float2|float3> pos)
 options:
     - DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski
+examples:
+    - /shaders/generative_worley.frag
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -19,37 +21,72 @@ license:
 #define WORLEY_DIST_FNC distEuclidean
 #endif
 
-float worley(float2 p){
+float2 worley(float2 p){
     float2 n = floor( p );
     float2 f = frac( p );
 
-    float dis = 1.0;
-    for( int j= -1; j <= 1; j++ )
+    float distF1 = 1.0;
+    float distF2 = 1.0;
+    float2 off1, pos1;
+    float2 off2, pos2;
+    for( int j= -1; j <= 1; j++ ) {
         for( int i=-1; i <= 1; i++ ) {	
-                float2  g = float2(i,j);
-                float2  o = random2( n + g );
-                float d = WORLEY_DIST_FNC(g+o, f);
-                dis = min(dis,d);
+            float2  g = float2(i,j);
+            float2  o = random2( n + g );
+            float2  p = g + o;
+            float d = WORLEY_DIST_FNC(p, f);
+            if (d < distF1) {
+                distF2 = distF1;
+                distF1 = d;
+                off2 = off1;
+                off1 = g;
+                pos2 = pos1;
+                pos1 = p;
+            }
+            else if (d < distF2) {
+                distF2 = d;
+                off2 = g;
+                pos2 = p;
+            }
+        }
     }
 
-    return 1.0-dis;
+    return float2(distF1, distF2);
 }
 
-float worley(float3 p){
+float2 worley(float3 p) {
     float3 n = floor( p );
     float3 f = frac( p );
 
-    float dis = 1.0;
-    for( int k = -1; k <= 1; k++ )
-        for( int j= -1; j <= 1; j++ )
+    float distF1 = 1.0;
+    float distF2 = 1.0;
+    float3 off1, pos1;
+    float3 off2, pos2;
+    for( int k = -1; k <= 1; k++ ) {
+        for( int j= -1; j <= 1; j++ ) {
             for( int i=-1; i <= 1; i++ ) {	
                 float3  g = float3(i,j,k);
                 float3  o = random3( n + g );
-                float d = WORLEY_DIST_FNC(g+o, f);
-                dis = min(dis,d);
+                float3  p = g + o;
+                float d = WORLEY_DIST_FNC(p, f);
+                if (d < distF1) {
+                    distF2 = distF1;
+                    distF1 = d;
+                    off2 = off1;
+                    off1 = g;
+                    pos2 = pos1;
+                    pos1 = p;
+                }
+                else if (d < distF2) {
+                    distF2 = d;
+                    off2 = g;
+                    pos2 = p;
+                }
+            }
+        }
     }
 
-    return 1.0-dis;
+    return float2(distF1, distF2);
 }
 
 #endif

--- a/generative/worley.hlsl
+++ b/generative/worley.hlsl
@@ -3,8 +3,8 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Worley noise
-use: <float2> worley(<float2|float3> pos)
+description: Worley noise. Returns float2(F1, F2)
+use: <float2> worley2(<float2|float3> pos)
 options:
     - WORLEY_JITTER: amount of pattern randomness. With 1.0 being the default and 0.0 resulting in a perfectly symmetrical pattern.
     - WORLEY_DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski

--- a/generative/worley.hlsl
+++ b/generative/worley.hlsl
@@ -6,7 +6,8 @@ contributors: Patricio Gonzalez Vivo
 description: Worley noise
 use: <float2> worley(<float2|float3> pos)
 options:
-    - DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski
+    - WORLEY_JITTER: amount of pattern randomness. With 1.0 being the default and 0.0 resulting in a perfectly symmetrical pattern.
+    - WORLEY_DIST_FNC: change the distance function, currently implemented are euclidean, manhattan, chebychev and minkowski
 examples:
     - /shaders/generative_worley.frag
 license:
@@ -16,6 +17,10 @@ license:
 
 #ifndef FNC_WORLEY
 #define FNC_WORLEY
+
+#ifndef WORLEY_DIST_FNC
+#define WORLEY_DIST_FNC distEuclidean
+#endif
 
 #ifndef WORLEY_DIST_FNC
 #define WORLEY_DIST_FNC distEuclidean
@@ -32,7 +37,7 @@ float2 worley(float2 p){
     for( int j= -1; j <= 1; j++ ) {
         for( int i=-1; i <= 1; i++ ) {	
             float2  g = float2(i,j);
-            float2  o = random2( n + g );
+            float2  o = random2( n + g ) * WORLEY_JITTER;
             float2  p = g + o;
             float d = WORLEY_DIST_FNC(p, f);
             if (d < distF1) {
@@ -66,7 +71,7 @@ float2 worley(float3 p) {
         for( int j= -1; j <= 1; j++ ) {
             for( int i=-1; i <= 1; i++ ) {	
                 float3  g = float3(i,j,k);
-                float3  o = random3( n + g );
+                float3  o = random3( n + g ) * WORLEY_JITTER;
                 float3  p = g + o;
                 float d = WORLEY_DIST_FNC(p, f);
                 if (d < distF1) {

--- a/generative/worley.hlsl
+++ b/generative/worley.hlsl
@@ -26,7 +26,7 @@ license:
 #define WORLEY_DIST_FNC distEuclidean
 #endif
 
-float2 worley(float2 p){
+float2 worley2(float2 p){
     float2 n = floor( p );
     float2 f = frac( p );
 
@@ -59,7 +59,11 @@ float2 worley(float2 p){
     return float2(distF1, distF2);
 }
 
-float2 worley(float3 p) {
+float worley(float2 p){
+    return 1.0-worley2(p).x;
+}
+
+float2 worley2(float3 p) {
     float3 n = floor( p );
     float3 f = frac( p );
 
@@ -92,6 +96,10 @@ float2 worley(float3 p) {
     }
 
     return float2(distF1, distF2);
+}
+
+float worley(float3 p){
+    return 1.0-worley2(p).x;
 }
 
 #endif

--- a/generative/worley.hlsl
+++ b/generative/worley.hlsl
@@ -18,8 +18,8 @@ license:
 #ifndef FNC_WORLEY
 #define FNC_WORLEY
 
-#ifndef WORLEY_DIST_FNC
-#define WORLEY_DIST_FNC distEuclidean
+#ifndef WORLEY_JITTER
+#define WORLEY_JITTER 1.0
 #endif
 
 #ifndef WORLEY_DIST_FNC


### PR DESCRIPTION
Currently, the `worley` function returns `1.0-F1` where F1 is the distance of a given point (which coordinates are passed as input param) to the closest seed point).

I modified it slightly to return `vec2(F1, F2)`, that is, the distances to the closest and second closest seed point, respectively.
This hands us a variety of noise patterns in a single function call (and very little overhead). F1 and F2 can be combined in many fun ways, including `F2-F1` which produces a lovely terrazzo-like pattern and can be thresholded to mimic scratches and wear.

I also added a WORLEY_JITTER option to modify the randomness of the Voronoi diagram, all the way down to 0, which results in a perfectly symmetrical pattern. The default is 1.0 (which is equivalent to the current behaviour).

These examples below are all based on the euclidean distance, but we could use any distance metrics from #161 for hours of noisy fun!

![worley2](https://github.com/user-attachments/assets/7e422c62-985a-4f15-a0df-98273cc5d42c)
