### PR TITLE
Updated HLSL samplers to DirectX 10 syntax

### DIFF
--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -1,6 +1,5 @@
-
+#include "../sampler.hlsl"
 #include "../math/powFast.hlsl"
-#include "../color/tonemap.hlsl"
 
 #include "fakeCube.hlsl"
 #include "toShininess.hlsl"
@@ -22,8 +21,7 @@ license:
 */
 
 #ifndef SAMPLE_CUBE_FNC
-//#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) texCUBElod(CUBEMAP, float4(NORM, LOD) )
-#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) CUBEMAP.SampleLevel(sampler##CUBEMAP, NORM, LOD)
+#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) CUBEMAP.SampleLevel(DEFAULT_SAMPLER_STATE, NORM, LOD)
 #endif
 
 #if defined(ENVMAP_MAX_MIP_LEVEL) && !defined(UNITY_COMPILER_HLSL)

--- a/sampler.hlsl
+++ b/sampler.hlsl
@@ -5,10 +5,17 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
+
+// https://docs.unity3d.com/Manual/SL-SamplerStates.html
+#ifndef DEFAULT_SAMPLER_STATE
+#define DEFAULT_SAMPLER_STATE defaultLinearClampSampler
+SamplerState DEFAULT_SAMPLER_STATE;
+#endif
+
 #ifndef SAMPLER_FNC
-#define SAMPLER_FNC(TEX, UV) tex2D(TEX, UV)
+#define SAMPLER_FNC(TEX, UV) TEX.Sample(DEFAULT_SAMPLER_STATE, UV)
 #endif
 
 #ifndef SAMPLER_TYPE
-#define SAMPLER_TYPE sampler2D
+#define SAMPLER_TYPE Texture2D
 #endif

--- a/sampler.hlsl
+++ b/sampler.hlsl
@@ -6,21 +6,35 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
-// https://docs.unity3d.com/Manual/SL-SamplerStates.html
-#ifndef DEFAULT_SAMPLER_STATE
-#define DEFAULT_SAMPLER_STATE defaultLinearClampSampler
-SamplerState DEFAULT_SAMPLER_STATE
-{
-    Filter = MIN_MAG_MIP_LINEAR;
-    AddressU = Clamp;
-    AddressV = Clamp;
-};
-#endif
+#if defined(__SHADER_TARGET_MAJOR) && __SHADER_TARGET_MAJOR < 4
 
-#ifndef SAMPLER_FNC
-#define SAMPLER_FNC(TEX, UV) TEX.Sample(DEFAULT_SAMPLER_STATE, UV)
-#endif
+    #ifndef SAMPLER_FNC
+    #define SAMPLER_FNC(TEX, UV) tex2D(TEX, UV)
+    #endif
 
-#ifndef SAMPLER_TYPE
-#define SAMPLER_TYPE Texture2D
+    #ifndef SAMPLER_TYPE
+    #define SAMPLER_TYPE sampler2D
+    #endif
+
+#else
+
+    // https://docs.unity3d.com/Manual/SL-SamplerStates.html
+    #ifndef DEFAULT_SAMPLER_STATE
+    #define DEFAULT_SAMPLER_STATE defaultLinearClampSampler
+    SamplerState DEFAULT_SAMPLER_STATE
+    {
+        Filter = MIN_MAG_MIP_LINEAR;
+        AddressU = Clamp;
+        AddressV = Clamp;
+    };
+    #endif
+
+    #ifndef SAMPLER_FNC
+    #define SAMPLER_FNC(TEX, UV) TEX.Sample(DEFAULT_SAMPLER_STATE, UV)
+    #endif
+
+    #ifndef SAMPLER_TYPE
+    #define SAMPLER_TYPE Texture2D
+    #endif
+
 #endif

--- a/sampler.hlsl
+++ b/sampler.hlsl
@@ -9,7 +9,12 @@ license:
 // https://docs.unity3d.com/Manual/SL-SamplerStates.html
 #ifndef DEFAULT_SAMPLER_STATE
 #define DEFAULT_SAMPLER_STATE defaultLinearClampSampler
-SamplerState DEFAULT_SAMPLER_STATE;
+SamplerState DEFAULT_SAMPLER_STATE
+{
+    Filter = MIN_MAG_MIP_LINEAR;
+    AddressU = Clamp;
+    AddressV = Clamp;
+};
 #endif
 
 #ifndef SAMPLER_FNC


### PR DESCRIPTION
Currently `SAMPLER_TYPE` is defined in HLSL as sampler2D, which is the obsolete DirectX 9 syntax from 2002.

This works fine with the old Unity Built-In render pipeline (BRP), which is itself deprecated.

However, it is not compatible with the newer URP and HDRP pipelines which are meant to supersede BRP. URP and HDRP use the Direct X 10 syntax (released in 2006).

Direct X 10 replaces the old `sampler2D` with Texture objects (eg. `Texture2D`) which also provide added benefits, like decoupling the texture object from the sampler state, querying size and max lod, etc...

Unreal also uses the DirectX 10 syntax exclusively.

This means texture-related functions in Lygia are currently unusable with Unity URP, Unity HDRP and Unreal.

I have updated the samplers to the DirectX 10 syntax in order to remedy this issue (which is also what has been done in the [Lygia Unreal Examples repo](https://github.com/franklzt/lygia_unreal_engine_examples)).

I have defined a default sample state `DEFAULT_SAMPLER_STATE defaultLinearClampSampler`, which means `SAMPLER_FNC(TEX, UV)` still takes two arguments and no other change is required in Lygia.

The new syntax is perfectly compatible with Unity BRP, however the examples need to be slightly updated (`sampler2D` becomes `Texture2D`), I'll follow up with a PR of the Unity examples as soon as this one is merged.