### PR TITLE
New feature: calculate normal from height map (GLSL and HLSL)

### DIFF
--- a/sample.glsl
+++ b/sample.glsl
@@ -29,3 +29,4 @@
 #include "sample/opticalFlow.glsl"
 #include "sample/smooth.glsl"
 #include "sample/zero.glsl"
+#include "sample/normalFromTexture.glsl"

--- a/sample.hlsl
+++ b/sample.hlsl
@@ -29,3 +29,4 @@
 #include "sample/opticalFlow.hlsl"
 #include "sample/smooth.hlsl"
 #include "sample/zero.hlsl"
+#include "sample/normalFromTexture.hlsl"

--- a/sample/normalFromTexture.glsl
+++ b/sample/normalFromTexture.glsl
@@ -1,0 +1,34 @@
+#include "../sampler.glsl"
+#include "../math/pow3.glsl"
+
+/*
+contributors: Shadi El Hajj
+description: Given a height map texture, calculate normal at point (s, t) 
+use: normalFromTexture(<SAMPLER_TYPE> heightMap, <vec2> st, <float> strength, <float> offset)
+options:
+    - SAMPLE_CHANNEL: texture channel to sample from. Defaults to 0 (red)
+*/
+
+#ifndef SAMPLE_CHANNEL
+#define SAMPLE_CHANNEL 0
+#endif
+
+vec3 normalFromTexture(SAMPLER_TYPE heightMap, vec2 st, float strength, float offset)
+{
+    offset = pow3(offset) * 0.1;
+    
+    float p = SAMPLER_FNC(heightMap, st)[SAMPLE_CHANNEL];
+    float h = SAMPLER_FNC(heightMap, st + vec2(offset, 0.0))[SAMPLE_CHANNEL];
+    float v = SAMPLER_FNC(heightMap, st + vec2(0.0, offset))[SAMPLE_CHANNEL];
+
+    vec3 a = vec3(1, 0, (h - p) * strength);
+    vec3 b = vec3(0, 1, (v - p) * strength);
+
+    return normalize(cross(a, b));
+}
+
+vec3 normalFromTexture(SAMPLER_TYPE heightMap, vec2 st, float strength)
+{
+    return normalFromTexture(heightMap, st, strength, 0.5);
+
+}

--- a/sample/normalFromTexture.hlsl
+++ b/sample/normalFromTexture.hlsl
@@ -1,0 +1,34 @@
+#include "../sampler.hlsl"
+#include "../math/pow3.hlsl"
+
+/*
+contributors: Shadi El Hajj
+description: Given a height map texture, calculate normal at point (s, t) 
+use: normalFromTexture(<SAMPLER_TYPE> heightMap, <vec2> st, <float> strength, <float> offset)
+options:
+    - SAMPLE_CHANNEL: texture channel to sample from. Defaults to 0 (red)
+*/
+
+#ifndef SAMPLE_CHANNEL
+#define SAMPLE_CHANNEL 0
+#endif
+
+float3 normalFromTexture(SAMPLER_TYPE heightMap, float2 st, float strength, float offset)
+{
+    offset = pow3(offset) * 0.1;
+    
+    float p = SAMPLER_FNC(heightMap, st)[SAMPLE_CHANNEL];
+    float h = SAMPLER_FNC(heightMap, st + float2(offset, 0.0))[SAMPLE_CHANNEL];
+    float v = SAMPLER_FNC(heightMap, st + float2(0.0, offset))[SAMPLE_CHANNEL];
+
+    float3 a = float3(1, 0, (h - p) * strength);
+    float3 b = float3(0, 1, (v - p) * strength);
+
+    return normalize(cross(a, b));
+}
+
+float3 normalFromTexture(SAMPLER_TYPE heightMap, float2 st, float strength)
+{
+    return normalFromTexture(heightMap, st, strength, 0.5);
+
+}


### PR DESCRIPTION
When displacing a grid based on a height map texture, we need to calculate the normals. This function does it for us.

Here's an example of 2048x2048 grid being displaced by a simple noise texture. Normals are calculated directly from the height maps using sample/normalFromTexture.
![Screenshot 2024-07-16 224230](https://github.com/user-attachments/assets/95193894-14a1-4a80-8cc7-5f2ab0e18fe1)
