### PR TITLE
Fixed raymarching camera (HLSL)

### DIFF
--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -28,6 +28,14 @@ license:
 #define RESOLUTION _ScreenParams.xy
 #endif
 
+#ifndef RAYMARCH_CAMERA_FOV
+#define RAYMARCH_CAMERA_FOV 3.0
+#endif
+
+#ifndef RAYMARCH_CAMERA_SCALE
+#define RAYMARCH_CAMERA_SCALE 0.11
+#endif
+
 #include "../math/const.hlsl"
 #include "../space/rotate.hlsl"
 #include "raymarch/render.hlsl"
@@ -44,15 +52,15 @@ float4 raymarch(float3 camera, float3 ta, float2 st) {
     float2 pixel = 1.0/ RESOLUTION;
     float2 offset = rotate( float2(0.5, 0.0), HALF_PI/4.);
 
-    for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
-        float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, 3.0)) );
-        color += RAYMARCH_RENDER_FNC( camera * 0.11, rd);
+    for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {    
+        float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, RAYMARCH_CAMERA_FOV)) );
+        color += RAYMARCH_RENDER_FNC( camera * RAYMARCH_CAMERA_SCALE, rd);
         offset = rotate(offset, HALF_PI);
     }
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
-    float3 rd = mul(ca, normalize( float3(st*2.0-1.0, 3.0) ) );
-    return RAYMARCH_RENDER_FNC( camera * 0.11, rd);
+    float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, RAYMARCH_CAMERA_FOV)));
+    return RAYMARCH_RENDER_FNC(camera * RAYMARCH_CAMERA_SCALE, rd);
 #endif
 }
 

--- a/lighting/raymarch/camera.hlsl
+++ b/lighting/raymarch/camera.hlsl
@@ -11,6 +11,9 @@ float3x3 raymarchCamera( in float3 ro, in float3 ta, in float3 up ) {
     float3 cw = normalize(ta-ro);
     float3 cu = normalize( cross(cw,up) );
     float3 cv = normalize( cross(cu,cw) );
+    // glsl is row-major anh hlsl column major.
+    // float3x3 is initialised with row vectors, but cu, cv and cw are columns vector
+    // thus, we need to transpose after initialization
     return transpose(float3x3(cu, cv, cw));
 }
 

--- a/lighting/raymarch/camera.hlsl
+++ b/lighting/raymarch/camera.hlsl
@@ -9,10 +9,9 @@ use: <float3x3> raymarchCamera(in <float3> ro, [in <float3> ta [, in <float3> up
 
 float3x3 raymarchCamera( in float3 ro, in float3 ta, in float3 up ) {
     float3 cw = normalize(ta-ro);
-    float3 cp = up;
-    float3 cu = normalize( cross(cw,cp) );
+    float3 cu = normalize( cross(cw,up) );
     float3 cv = normalize( cross(cu,cw) );
-    return float3x3( cu, cv, cw );
+    return transpose(float3x3(cu, cv, cw));
 }
 
 float3x3 raymarchCamera( in float3 ro, in float3 ta, float cr ) {
@@ -20,7 +19,7 @@ float3x3 raymarchCamera( in float3 ro, in float3 ta, float cr ) {
     float3 cp = float3(sin(cr), cos(cr),0.0);
     float3 cu = normalize( cross(cw,cp) );
     float3 cv =          ( cross(cu,cw) );
-    return float3x3( cu, cv, cw );
+    return transpose(float3x3(cu, cv, cw));
 }
 
 float3x3 raymarchCamera( in float3 ro, in float3 ta ) {


### PR DESCRIPTION
Ok, this one gave me a hard time 😅

Raymarching camera was broken in hlsl and rotating in erratic ways when moved.
Turns out the culprit was matrix layout in `raymarch/camera.hlsl`:
glsl is row-major anh hlsl column major. The returned `float3x3` is initialised with row vectors, but `cu`, `cv` and `cw` are column vectors. Thus, we need to transpose the matrix before returning it (HLSL only).

There might def be similar errors elsewhere in the HLSL, I'll try to find a moment to track them down.