### PR TITLE
Improved raymarching shadow quality (HLSL and GLSL)

### DIFF
--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -5,12 +5,29 @@
 contributors:  Inigo Quiles
 description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
 use: <float> raymarchSoftshadow( in <vec3> ro, in <vec3> rd, in <float> tmin, in <float> tmax) 
+options:
+    - RAYMARCHSOFTSHADOW_ITERATIONS: shadow quality
+    - RAYMARCH_SHADOW_MIN_DIST: minimum shadow distance
+    - RAYMARCH_SHADOW_MAX_DIST: maximum shadow distance
+    - RAYMARCH_SHADOW_SOLID_ANGLE: light size
 examples:
     - /shaders/lighting_raymarching.frag
 */
 
 #ifndef RAYMARCHSOFTSHADOW_ITERATIONS
-#define RAYMARCHSOFTSHADOW_ITERATIONS 16
+#define RAYMARCHSOFTSHADOW_ITERATIONS 64
+#endif
+
+#ifndef RAYMARCH_SHADOW_MIN_DIST
+#define RAYMARCH_SHADOW_MIN_DIST 0.01
+#endif
+
+#ifndef RAYMARCH_SHADOW_MAX_DIST
+#define RAYMARCH_SHADOW_MAX_DIST 3.0
+#endif
+
+#ifndef RAYMARCH_SHADOW_SOLID_ANGLE
+#define RAYMARCH_SHADOW_SOLID_ANGLE 0.1
 #endif
 
 #ifndef RAYMARCH_MAP_FNC
@@ -24,31 +41,22 @@ examples:
 #ifndef FNC_RAYMARCHSOFTSHADOW
 #define FNC_RAYMARCHSOFTSHADOW
 
-float raymarchSoftShadow( vec3 ro, vec3 rd, in float tmin, in float tmax, float k ) {
+float raymarchSoftShadow(vec3 ro, vec3 rd, in float mint, in float maxt, float w) {
     float res = 1.0;
-    float t = tmin;
-    float ph = 1e20;
-    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
-        float h = RAYMARCH_MAP_FNC(ro + rd*t).RAYMARCH_MAP_DISTANCE;
-
-        if (t > tmax)
+    float t = mint;
+    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++)
+    {
+        float h = RAYMARCH_MAP_FNC(ro + t * rd).RAYMARCH_MAP_DISTANCE;
+        res = min(res, h / (w * t));
+        t += clamp(h, 0.005, 0.50);
+        if (res < -1.0 || t > maxt)
             break;
-
-        else if (h < 0.001) {
-            res = 0.0;
-            break;
-        }
-
-        float y = h*h/(2.0*ph);
-        float d = sqrt(h*h-y*y);
-        res = min( res, k*d/max(0.0,t-y) );
-        ph = h;
-        t += h;
     }
-    return res;
+    res = max(res, -1.0);
+    return 0.25 * (1.0 + res) * (1.0 + res) * (2.0 - res);
 }
 
-float raymarchSoftShadow( vec3 ro, vec3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, tmin, tmax, 12.0); }
-float raymarchSoftShadow( vec3 ro, vec3 rd) { return raymarchSoftShadow(ro, rd, 0.05, 5.0); }
+float raymarchSoftShadow(vec3 ro, vec3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST, RAYMARCH_SHADOW_SOLID_ANGLE); }
+float raymarchSoftShadow(vec3 ro, vec3 rd) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST); }
 
 #endif

--- a/lighting/raymarch/softShadow.hlsl
+++ b/lighting/raymarch/softShadow.hlsl
@@ -3,11 +3,28 @@
 /*
 contributors:  Inigo Quiles
 description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
-use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin, in <float> tmax) 
+use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin, in <float> tmax)
+options:
+    - RAYMARCHSOFTSHADOW_ITERATIONS: shadow quality
+    - RAYMARCH_SHADOW_MIN_DIST: minimum shadow distance
+    - RAYMARCH_SHADOW_MAX_DIST: maximum shadow distance
+    - RAYMARCH_SHADOW_SOLID_ANGLE: light size
 */
 
 #ifndef RAYMARCHSOFTSHADOW_ITERATIONS
-#define RAYMARCHSOFTSHADOW_ITERATIONS 16
+#define RAYMARCHSOFTSHADOW_ITERATIONS 64
+#endif
+
+#ifndef RAYMARCH_SHADOW_MIN_DIST
+#define RAYMARCH_SHADOW_MIN_DIST 0.01
+#endif
+
+#ifndef RAYMARCH_SHADOW_MAX_DIST
+#define RAYMARCH_SHADOW_MAX_DIST 3.0
+#endif
+
+#ifndef RAYMARCH_SHADOW_SOLID_ANGLE
+#define RAYMARCH_SHADOW_SOLID_ANGLE 0.1
 #endif
 
 #ifndef RAYMARCH_MAP_FNC
@@ -21,31 +38,22 @@ use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin
 #ifndef FNC_RAYMARCHSOFTSHADOW
 #define FNC_RAYMARCHSOFTSHADOW
 
-float raymarchSoftShadow( float3 ro, float3 rd, in float tmin, in float tmax, float k ) {
+float raymarchSoftShadow( float3 ro, float3 rd, in float mint, in float maxt, float w ) {
     float res = 1.0;
-    float t = tmin;
-    float ph = 1e20;
-    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
-        float h = RAYMARCH_MAP_FNC(ro + rd*t).RAYMARCH_MAP_DISTANCE;
-
-        if (t > tmax)
+    float t = mint;
+    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++)
+    {
+        float h = RAYMARCH_MAP_FNC(ro + t * rd).RAYMARCH_MAP_DISTANCE;
+        res = min(res, h / (w * t));
+        t += clamp(h, 0.005, 0.50);
+        if (res < -1.0 || t > maxt)
             break;
-
-        else if (h < 0.001) {
-            res = 0.0;
-            break;
-        }
-
-        float y = h*h/(2.0*ph);
-        float d = sqrt(h*h-y*y);
-        res = min( res, k*d/max(0.0,t-y) );
-        ph = h;
-        t += h;
     }
-    return res;
+    res = max(res, -1.0);
+    return 0.25 * (1.0 + res) * (1.0 + res) * (2.0 - res);
 }
 
-float raymarchSoftShadow( float3 ro, float3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, tmin, tmax, 12.0); }
-float raymarchSoftShadow( float3 ro, float3 rd) { return raymarchSoftShadow(ro, rd, 0.05, 5.0); }
+float raymarchSoftShadow( float3 ro, float3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST, RAYMARCH_SHADOW_SOLID_ANGLE); }
+float raymarchSoftShadow( float3 ro, float3 rd) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST); }
 
 #endif


### PR DESCRIPTION
* Improved raymarching soft shadow quality
* Exposed more more shadow params:
    - RAYMARCH_SHADOW_MIN_DIST: minimum shadow distance
    - RAYMARCH_SHADOW_MAX_DIST: maximum shadow distance
    - RAYMARCH_SHADOW_SOLID_ANGLE: light size

This is ported from Inigo's article  [soft shadows in raymarched SDFs](https://iquilezles.org/articles/rmshadows/)

Before (notice the unrealistic shadow of the prism)
![Screenshot 2024-07-23 212717](https://github.com/user-attachments/assets/4a650b11-da71-4fbd-b275-15f88abe80e4)

After
![Screenshot 2024-07-23 212731](https://github.com/user-attachments/assets/9ed72102-c407-4a1e-ad25-23bcbd14846e)
