### PR TITLE
Added shadow and support to Raymarched PBR

### DIFF
--- a/lighting/light/directional.glsl
+++ b/lighting/light/directional.glsl
@@ -39,7 +39,7 @@ void lightDirectional(
     
     float intensity = _Li;
     #ifdef RAYMARCH_SHADOWS    
-    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    intensity = raymarchSoftShadow(_P, _Ld);
     #endif 
 
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -41,7 +41,7 @@ void lightDirectional(
 
     float intensity = _Li;
     #ifdef RAYMARCH_SHADOWS    
-    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    intensity = raymarchSoftShadow(_P, _Ld);
     #endif    
 
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);

--- a/lighting/light/directional.hlsl
+++ b/lighting/light/directional.hlsl
@@ -1,6 +1,6 @@
 #include "../specular.hlsl"
 #include "../diffuse.hlsl"
-#include "falloff.hlsl"
+#include "../raymarch/softShadow.hlsl"
 
 /*
 contributors: Patricio Gonzalez Vivo
@@ -12,6 +12,7 @@ options:
     - LIGHT_DIRECTION
     - LIGHT_COLOR: Color
     - LIGHT_INTENSITY: Intensity
+    - RAYMARCH_SHADOWS: enable raymarched shadows
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -34,15 +35,20 @@ void lightDirectional(
     const in float3 _diffuseColor, const in float3 _specularColor,
     const in float3 _V,
     const in float3 _Ld, const in float3 _Lc, const in float _Li,
-    const in float3 _N, const in float _NoV, const in float _NoL,
+    const in float3 _P, const in float3 _N, const in float _NoV, const in float _NoL,
     const in float _roughness, const in float _f0,
-    inout float3 _diffuse, inout float3 _specular)
-{
+    inout float3 _diffuse, inout float3 _specular) {
+
+    float intensity = _Li;
+    #ifdef RAYMARCH_SHADOWS    
+    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    #endif    
+
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);
     float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    _diffuse += max(float3(0.0, 0.0, 0.0), _Li * (_diffuseColor * _Lc * dif) * _NoL);
-    _specular += max(float3(0.0, 0.0, 0.0), _Li * (_specularColor * _Lc * spec) * _NoL);
+    _diffuse += max(float3(0.0, 0.0, 0.0), intensity * (_diffuseColor * _Lc * dif) * _NoL);
+    _specular += max(float3(0.0, 0.0, 0.0), intensity * (_specularColor * _Lc * spec) * _NoL);
 }
 
 #ifdef STR_MATERIAL
@@ -58,7 +64,7 @@ void lightDirectional(
         _diffuseColor, _specularColor, 
         _mat.V, 
         _L.direction, _L.color, _L.intensity,
-        _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
+        _mat.position, _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
         _diffuse, _specular);
 
 #ifdef SHADING_MODEL_SUBSURFACE

--- a/lighting/light/point.glsl
+++ b/lighting/light/point.glsl
@@ -41,7 +41,7 @@ void lightPoint(
 
     float intensity = _Li;
     #ifdef RAYMARCH_SHADOWS    
-    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    intensity = raymarchSoftShadow(_P, _Ld);
     #endif
 
     float dif   = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);// * INV_PI;

--- a/lighting/light/point.glsl
+++ b/lighting/light/point.glsl
@@ -16,7 +16,7 @@ license:
 
 #include "../specular.glsl"
 #include "../diffuse.glsl"
-#include "../shadow.glsl"
+#include "../raymarch/softShadow.glsl"
 #include "falloff.glsl"
 
 #ifndef STR_LIGHT_POINT
@@ -36,13 +36,18 @@ void lightPoint(
     const in vec3 _diffuseColor, const in vec3 _specularColor, 
     const in vec3 _V, 
     const in vec3 _Lp, const in vec3 _Ld, const in vec3 _Lc, const in float _Li, const in float _Ldist, const in float _Lof, 
-    const in vec3 _N, const in float _NoV, const in float _NoL, const in float _roughness, const in float _f0, 
+    const in vec3 _P, const in vec3 _N, const in float _NoV, const in float _NoL, const in float _roughness, const in float _f0,
     inout vec3 _diffuse, inout vec3 _specular) {
+
+    float intensity = _Li;
+    #ifdef RAYMARCH_SHADOWS    
+    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    #endif
 
     float dif   = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness);// * INV_PI;
     float spec  = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    vec3 lightContribution = _Lc * _Li * _NoL;
+    vec3 lightContribution = _Lc * intensity * _NoL;
     if (_Lof > 0.0)
         lightContribution *= falloff(_Ldist, _Lof);
 
@@ -65,7 +70,7 @@ void lightPoint(
     lightPoint( _diffuseColor, _specularColor, 
                 _mat.V, 
                 _L.position, L, _L.color, _L.intensity, dist, _L.falloff, 
-                _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
+                _mat.position, _mat.normal, _mat.NoV, NoL, _mat.roughness, f0,
                 _diffuse, _specular);
 
     // TODO:

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -16,6 +16,7 @@ license:
 
 #include "../specular.hlsl"
 #include "../diffuse.hlsl"
+#include "../raymarch/softShadow.hlsl"
 #include "falloff.hlsl"
 
 #ifndef STR_LIGHT_POINT
@@ -36,14 +37,18 @@ void lightPoint(
     const in float3 _diffuseColor, const in float3 _specularColor,
     const in float3 _V,
     const in float3 _Lp, const in float3 _Ld, const in float3 _Lc, const in float _Li, const in float _Ldist, const in float _Lof,
-    const in float3 _N, const in float _NoV, const in float _NoL, const in float _roughness, const in float _f0,
-    inout float3 _diffuse, inout float3 _specular)
-{
+    const in float3 _P, const in float3 _N, const in float _NoV, const in float _NoL, const in float _roughness, const in float _f0,
+    inout float3 _diffuse, inout float3 _specular) {
 
+    float intensity = _Li;
+    #ifdef RAYMARCH_SHADOWS    
+    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    #endif
+    
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness); // * INV_PI;
     float spec = specular(_Ld, _N, _V, _NoV, _NoL, _roughness, _f0);
 
-    float3 lightContribution = _Lc * _Li * _NoL;
+    float3 lightContribution = _Lc * intensity * _NoL;
     if (_Lof > 0.0)
         lightContribution *= falloff(_Ldist, _Lof);
 
@@ -66,7 +71,7 @@ void lightPoint(
     lightPoint( _diffuseColor, _specularColor, 
                 _mat.V, 
                 _L.position, L, _L.color, _L.intensity, dist, _L.falloff, 
-                _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
+                _mat.position, _mat.normal, _mat.NoV, NoL, _mat.roughness, f0, 
                 _diffuse, _specular);
 
     // TODO:

--- a/lighting/light/point.hlsl
+++ b/lighting/light/point.hlsl
@@ -42,7 +42,7 @@ void lightPoint(
 
     float intensity = _Li;
     #ifdef RAYMARCH_SHADOWS    
-    intensity = raymarchSoftShadow(_P, _Ld, 0.02, 2.5);
+    intensity = raymarchSoftShadow(_P, _Ld);
     #endif
     
     float dif = diffuse(_Ld, _N, _V, _NoV, _NoL, _roughness); // * INV_PI;

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -12,6 +12,8 @@
 #include "common/specularAO.glsl"
 #include "common/envBRDFApprox.glsl"
 
+#include "raymarch/ao.glsl"
+
 /*
 contributors: Patricio Gonzalez Vivo
 description: Simple PBR shading model
@@ -53,16 +55,21 @@ vec4 pbr(const in Material _mat) {
 
     // Ambient Occlusion
     // ------------------------
-    float ssao = 1.0;
+    float ao = 1.0;
+
+    #if defined(RAYMARCH_AO)
+    ao = raymarchAO(M.position, M.normal);
+    #endif
+
 // #if defined(FNC_SSAO) && defined(SCENE_DEPTH) && defined(RESOLUTION) && defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)
 //     vec2 pixel = 1.0/RESOLUTION;
-//     ssao = ssao(SCENE_DEPTH, gl_FragCoord.xy*pixel, pixel, 1.);
+//     ao = ssao(SCENE_DEPTH, gl_FragCoord.xy*pixel, pixel, 1.);
 // #endif 
 
     // Global Ilumination ( Image Based Lighting )
     // ------------------------
     vec3 E = envBRDFApprox(specularColor, M);
-    float diffuseAO = min(M.ambientOcclusion, ssao);
+    float diffuseAO = min(M.ambientOcclusion, ao);
 
     vec3 Fr = vec3(0.0, 0.0, 0.0);
     Fr  = envMap(M) * E;

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -24,6 +24,7 @@ options:
     - LIGHT_POSITION: in GlslViewer is u_light
     - LIGHT_COLOR in GlslViewer is u_lightColor
     - CAMERA_POSITION: in GlslViewer is u_camera
+    - RAYMARCH_AO: enabled raymarched ambient occlusion
 examples:
     - /shaders/lighting_raymarching_pbr.frag
 license:

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -52,6 +52,7 @@ options:
     - LIGHT_POSITION: in glslViewer is u_light
     - LIGHT_COLOR in glslViewer is u_lightColor
     - CAMERA_POSITION: in glslViewer is u_camera
+    - RAYMARCH_AO: enabled raymarched ambient occlusion
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -40,6 +40,8 @@
 #include "common/specularAO.hlsl"
 #include "common/envBRDFApprox.hlsl"
 
+#include "raymarch/ao.hlsl"
+
 /*
 contributors: Patricio Gonzalez Vivo
 description: Simple PBR shading model
@@ -71,16 +73,21 @@ float4 pbr(const Material _mat) {
 
     // Ambient Occlusion
     // ------------------------
-    float ssao = 1.0;
+    float ao = 1.0;
+    
+    #if defined(RAYMARCH_AO)
+    ao = raymarchAO(M.position, M.normal);
+    #endif
+
 // #if defined(FNC_SSAO) && defined(SCENE_DEPTH) && defined(RESOLUTION) && defined(CAMERA_NEAR_CLIP) && defined(CAMERA_FAR_CLIP)
 //     vec2 pixel = 1.0/RESOLUTION;
-//     ssao = ssao(SCENE_DEPTH, gl_FragCoord.xy*pixel, pixel, 1.);
+//     ao = ssao(SCENE_DEPTH, gl_FragCoord.xy*pixel, pixel, 1.);
 // #endif 
 
     // Global Ilumination ( Image Based Lighting )
     // ------------------------
     float3 E = envBRDFApprox(specularColor, M);
-    float diffuseAO = min(M.ambientOcclusion, ssao);
+    float diffuseAO = min(M.ambientOcclusion, ao);
     
     float3 Fr = float3(0.0, 0.0, 0.0);
     Fr = envMap(M) * E;

--- a/lighting/raymarch/material.glsl
+++ b/lighting/raymarch/material.glsl
@@ -78,8 +78,8 @@ vec3 raymarchDefaultMaterial(vec3 ray, vec3 position, vec3 normal, RAYMARCH_MAP_
     float dom = smoothstep( -0.1, 0.1, ref.y );
     float fre = pow( saturate(1.0+dot(normal,ray) ), 2.0 );
     
-    dif *= raymarchSoftShadow( position, lig, 0.02, 2.5 );
-    dom *= raymarchSoftShadow( position, ref, 0.02, 2.5 );
+    dif *= raymarchSoftShadow( position, lig );
+    dom *= raymarchSoftShadow( position, ref );
 
     vec3 light = vec3(0.0);
     light += 1.30 * dif * LIGHT_COLOR;

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -75,8 +75,8 @@ float3 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMA
     float dom = smoothstep( -0.1, 0.1, ref.y );
     float fre = pow( saturate(1.0+dot(normal,ray) ), 2.0 );
     
-    dif *= raymarchSoftShadow( position, lig, 0.02, 2.5 );
-    dom *= raymarchSoftShadow( position, ref, 0.02, 2.5 );
+    dif *= raymarchSoftShadow( position, lig );
+    dom *= raymarchSoftShadow( position, ref );
 
     float3 light = float3(0.0, 0.0, 0.0);
     light += 1.30 * dif * LIGHT_COLOR;


### PR DESCRIPTION
When using PBR with raymarching, soft shadows and ambient occlusion can be turned on with
- `#define RAYMARCH_SHADOWS`
- `#define RAYMARCH_AO`

Default raymarching material
![Screenshot 2024-07-23 224507](https://github.com/user-attachments/assets/90430b0c-2927-48e2-8ecc-0f640e8db57c)

Raymarched PBR
![Screenshot 2024-07-23 230017](https://github.com/user-attachments/assets/927b4d2c-7dde-48c9-a68e-4a4d0d8fea8a)

Raymarched PBR with soft shadows
![Screenshot 2024-07-23 230027](https://github.com/user-attachments/assets/141dfa04-1756-4be4-b373-639fc68738b2)

Raymarched PBR with soft shadows and AO
![Screenshot 2024-07-23 230040](https://github.com/user-attachments/assets/444131d5-4e31-457d-9ab9-9a065f1dc636)
