### PR TITLE
Various HLSL SDF Fixes

### DIFF
--- a/lighting/diffuse/lambert.hlsl
+++ b/lighting/diffuse/lambert.hlsl
@@ -1,4 +1,4 @@
-#include "../../math/const.glsl"
+#include "../../math/const.hlsl"
 
 /*
 contributors: Patricio Gonzalez Vivo

--- a/lighting/raymarch/volume.glsl
+++ b/lighting/raymarch/volume.glsl
@@ -87,7 +87,7 @@ vec4 raymarchVolume( in vec3 ro, in vec3 rd ) {
             #ifdef LIGHT_POSITION
             float Tl = 1.0;
             for (int j = 0; j < nbSampleLight; j++) {
-                float densityLight = raymarchMap( pos + sun_direction * float(j) * tstepl ).a;
+                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).a;
                 if (densityLight>0.)
                     Tl *= 1. - densityLight * absorption/fSamples;
                 if (Tl <= 0.01)

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -1,5 +1,3 @@
-#include "../../math/saturate.hlsl"
-
 /*
 contributors:  Inigo Quiles
 description: Default raymarching renderer

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -83,7 +83,7 @@ float4 raymarchVolume( in float3 ro, in float3 rd ) {
             #ifdef LIGHT_POSITION
             float Tl = 1.0;
             for (int j = 0; j < nbSampleLight; j++) {
-                float densityLight = raymarchMap( pos + sun_direction * float(j) * tstepl ).a;
+                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).a;
                 if (densityLight>0.)
                     Tl *= 1. - densityLight * absorption/fSamples;
                 if (Tl <= 0.01)

--- a/sdf.hlsl
+++ b/sdf.hlsl
@@ -11,6 +11,7 @@
 #include "sdf/superShapeSDF.hlsl"
 #include "sdf/triSDF.hlsl"
 #include "sdf/vesicaSDF.hlsl"
+#include "sdf/flowerSDF.hlsl"
 
 // 3D
 #include "sdf/boxFrameSDF.hlsl"
@@ -40,4 +41,5 @@
 #include "sdf/opRevolve.hlsl"
 #include "sdf/opRound.hlsl"
 #include "sdf/opSubtraction.hlsl"
+#include "sdf/opIntersection.hlsl"
 #include "sdf/opUnion.hlsl"

--- a/sdf/flowerSDF.hlsl
+++ b/sdf/flowerSDF.hlsl
@@ -9,7 +9,7 @@ license:
 
 #ifndef FNC_FLOWERSDF
 #define FNC_FLOWERSDF
-float flowerSDF(vec2 st, int N) {
+float flowerSDF(float2 st, int N) {
 #ifdef CENTER_2D
     st -= CENTER_2D;
 #else


### PR DESCRIPTION
* Fixed `flowerSDF.hlsl` (`float2` instead of `vec2`)
* Fixed include in `lambert.hlsl`
* Added missing includes to `sdf.hlsl`
* Fixed include in `volume.sdf` (`saturate` is a built-in in HLSL)
* Parametrised `raymarchMap` in `volume.hlsl` `volume.glsl`
