### PR TITLE
envMap automatic MIP level (GLSL)

### DIFF
--- a/lighting/envMap.glsl
+++ b/lighting/envMap.glsl
@@ -20,10 +20,14 @@ license:
 */
 
 #ifndef SAMPLE_CUBE_FNC
+#if __VERSION__ >= 300
+#define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) texture(CUBEMAP, NORM, LOD)
+#else
 #define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) textureCube(CUBEMAP, NORM, LOD)
 #endif
+#endif
 
-#ifndef ENVMAP_MAX_MIP_LEVEL
+#if __VERSION__ < 430
 #define ENVMAP_MAX_MIP_LEVEL 3.0
 #endif
 
@@ -39,6 +43,10 @@ vec3 envMap(const in vec3 _normal, const in float _roughness, const in float _me
     return sampleEquirect(SCENE_EQUIRECT, _normal, 1.0 + 26.0 * _roughness).rgb;
 
 // Cubemap sampling
+#elif defined(SCENE_CUBEMAP) && !defined(ENVMAP_MAX_MIP_LEVEL)
+    int levels = textureQueryLevels( SCENE_CUBEMAP );
+    return SAMPLE_CUBE_FNC( SCENE_CUBEMAP, _normal, levels * _roughness).rgb;
+
 #elif defined(SCENE_CUBEMAP)
     return SAMPLE_CUBE_FNC( SCENE_CUBEMAP, _normal, (ENVMAP_MAX_MIP_LEVEL * _roughness) ).rgb;
 

--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -24,10 +24,6 @@ license:
 #define SAMPLE_CUBE_FNC(CUBEMAP, NORM, LOD) CUBEMAP.SampleLevel(DEFAULT_SAMPLER_STATE, NORM, LOD)
 #endif
 
-#if defined(ENVMAP_MAX_MIP_LEVEL) && !defined(UNITY_COMPILER_HLSL)
-#define ENVMAP_MAX_MIP_LEVEL 3.0
-#endif
-
 #ifndef FNC_ENVMAP
 #define FNC_ENVMAP
 float3 envMap(float3 _normal, float _roughness, float _metallic) {


### PR DESCRIPTION
This is a follow-up to #154 and implements similar functionality in GLSL. Unlike the HLSL version, no changes are required on the user's end. For incompatible systems (OpenGL < 4.3) we automatically revert to the old behaviour.

As a reminder:
Currently Lygia assumes a default ENVMAP_MAX_MIP_LEVEL of 3, which is:

Dependent on the resolution of the texture
Very low for typical 2k cubemap textures.
This results in cubemaps not being sufficiently blurred when using rough materials.
The new system is resolution independent and guarantees correct blurring levels.

ENVMAP_MAX_MIP_LEVEL can still be used to override the automatic setting if desired.

![346299900-441fcff7-5f89-4505-ae3c-cf5fabf3d155](https://github.com/user-attachments/assets/91da49ad-0df9-4e92-b48d-bdf9aedd5ef7)
