### PR TITLE
Changes to raymarching camera FOV

### DIFF
--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -40,7 +40,7 @@ license:
 #define ENG_RAYMARCHING
 vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
     mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
-    float fov = 2.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
 
 #if defined(RAYMARCH_MULTISAMPLE)
     vec4 color = vec4(0.0);

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -28,11 +28,7 @@ license:
 #endif
 
 #ifndef RAYMARCH_CAMERA_FOV
-#define RAYMARCH_CAMERA_FOV 3.0
-#endif
-
-#ifndef RAYMARCH_CAMERA_SCALE
-#define RAYMARCH_CAMERA_SCALE 0.11
+#define RAYMARCH_CAMERA_FOV 60.0
 #endif
 
 #include "../math/const.glsl"
@@ -44,21 +40,22 @@ license:
 #define ENG_RAYMARCHING
 vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
     mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
-    
+    float fov = 2.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+
 #if defined(RAYMARCH_MULTISAMPLE)
     vec4 color = vec4(0.0);
     vec2 pixel = 1.0/RESOLUTION;
     vec2 offset = rotate( vec2(0.5, 0.0), HALF_PI/4.);
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
-        vec3 rd = ca * normalize(vec3((st + offset * pixel)*2.0-1.0, RAYMARCH_CAMERA_FOV));
-        color += RAYMARCH_RENDER_FNC( camera * RAYMARCH_CAMERA_SCALE, rd);
+        vec3 rd = ca * normalize(vec3((st + offset * pixel)*2.0-1.0, fov));
+        color += RAYMARCH_RENDER_FNC( camera, rd);
         offset = rotate(offset, HALF_PI);
     }
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
-    vec3 rd = ca * normalize(vec3(st*2.0-1.0, RAYMARCH_CAMERA_FOV));
-    return RAYMARCH_RENDER_FNC( camera * RAYMARCH_CAMERA_SCALE, rd);
+    vec3 rd = ca * normalize(vec3(st*2.0-1.0, fov));
+    return RAYMARCH_RENDER_FNC( camera, rd);
 #endif
 }
 

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -41,6 +41,7 @@ license:
 vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
     mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
     float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    st.x = 1.0 - st.x;
 
 #if defined(RAYMARCH_MULTISAMPLE)
     vec4 color = vec4(0.0);

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -29,11 +29,7 @@ license:
 #endif
 
 #ifndef RAYMARCH_CAMERA_FOV
-#define RAYMARCH_CAMERA_FOV 3.0
-#endif
-
-#ifndef RAYMARCH_CAMERA_SCALE
-#define RAYMARCH_CAMERA_SCALE 0.11
+#define RAYMARCH_CAMERA_FOV 60.0
 #endif
 
 #include "../math/const.hlsl"
@@ -46,6 +42,7 @@ license:
 
 float4 raymarch(float3 camera, float3 ta, float2 st) {
     float3x3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
+    float fov = 2.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
     
 #if defined(RAYMARCH_MULTISAMPLE)
     float4 color = float4(0.0, 0.0, 0.0, 0.0);
@@ -53,14 +50,14 @@ float4 raymarch(float3 camera, float3 ta, float2 st) {
     float2 offset = rotate( float2(0.5, 0.0), HALF_PI/4.);
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {    
-        float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, RAYMARCH_CAMERA_FOV)) );
-        color += RAYMARCH_RENDER_FNC( camera * RAYMARCH_CAMERA_SCALE, rd);
+        float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, fov)) );
+        color += RAYMARCH_RENDER_FNC( camera, rd);
         offset = rotate(offset, HALF_PI);
     }
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
-    float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, RAYMARCH_CAMERA_FOV)));
-    return RAYMARCH_RENDER_FNC(camera * RAYMARCH_CAMERA_SCALE, rd);
+    float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, fov)));
+    return RAYMARCH_RENDER_FNC(camera, rd);
 #endif
 }
 

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -42,7 +42,7 @@ license:
 
 float4 raymarch(float3 camera, float3 ta, float2 st) {
     float3x3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
-    float fov = 2.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
     
 #if defined(RAYMARCH_MULTISAMPLE)
     float4 color = float4(0.0, 0.0, 0.0, 0.0);

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -43,6 +43,7 @@ license:
 float4 raymarch(float3 camera, float3 ta, float2 st) {
     float3x3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
     float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    st.x = 1.0 - st.x;
     
 #if defined(RAYMARCH_MULTISAMPLE)
     float4 color = float4(0.0, 0.0, 0.0, 0.0);

--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -11,7 +11,7 @@ use: <float> castRay( in <vec3> pos, in <vec3> nor )
 #endif
 
 #ifndef RAYMARCH_MIN_DIST
-#define RAYMARCH_MIN_DIST 1.0
+#define RAYMARCH_MIN_DIST 0.1
 #endif
 
 #ifndef RAYMARCH_MAX_DIST

--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -7,7 +7,7 @@ use: <float> castRay( in <vec3> pos, in <vec3> nor )
 */
 
 #ifndef RAYMARCH_SAMPLES
-#define RAYMARCH_SAMPLES 64
+#define RAYMARCH_SAMPLES 256
 #endif
 
 #ifndef RAYMARCH_MIN_DIST

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -7,7 +7,7 @@ use: <float> castRay( in <float3> pos, in <float3> nor )
 */
 
 #ifndef RAYMARCH_SAMPLES
-#define RAYMARCH_SAMPLES 64
+#define RAYMARCH_SAMPLES 256
 #endif
 
 #ifndef RAYMARCH_MIN_DIST

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -11,7 +11,7 @@ use: <float> castRay( in <float3> pos, in <float3> nor )
 #endif
 
 #ifndef RAYMARCH_MIN_DIST
-#define RAYMARCH_MIN_DIST 1.0
+#define RAYMARCH_MIN_DIST 0.1
 #endif
 
 #ifndef RAYMARCH_MAX_DIST


### PR DESCRIPTION
This one is a bit tricky as it will affect existing scenes, but I think it’s something we’ll have to grapple with sooner or later.

There are 3 issues:
1. In `lighting/raymarch`, the camera position is being multiplied by a factor named `RAYMARCH_CAMERA_SCALE` which defaults to an apparently arbitrary `0.11`. Unless I’m missing something, I can’t see the rationale or the usefulness of this. But more importantly, it leads to the scene and the camera having different coordinate systems. It’s as if the scene is specified in meters and the camera in cms (except the factor is 0.11, not 0.1).
For a 1m quad to cover a 60 degrees camera viewport, the camera currently needs to be positioned 7.89m away which is absurd and counter-intuitive (some basic trigonometry shows it should be just 0.86m)
2. `RAYMARCH_CAMERA_FOV`is currently specified as the inverse of the tangent of the half FOV angle. This is not intuitive, especially since decreasing this value leads to a higher FOV.
3. The x-axis is flipped. Moving an object along the positive x-axis visually displaces it to the left. Again, not very intuitive.

Proposed changes:
1. Get rid of `RAYMARCH_CAMERA_SCALE` altogether. I don’t see any case where we would want to have anything but 1 here. Or at least, set the default to one.
2. Specify `RAYMARCH_CAMERA_FOV`in degrees (vertical FOV), and default to 60.
3. Flip the x-axis, so that the positive x-axis points to the right, as it’s usual with cartesian coordinate systems.

I've applied these changes to both GLSL and HLSL versions.
I’ve also back-to-backed these changes against the Unity camera to make sure it's behaving consistently and in a physically correct manner.

Keen to hear your thoughts on this one @patriciogonzalezvivo.