### PR TITLE
PBR: fallback to environment sampling if Spherical Harmonics are not present.

### DIFF
--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -84,6 +84,8 @@ vec4 pbr(const in Material _mat) {
     vec3 Fd = diffuseColor;
     #if defined(SCENE_SH_ARRAY)
     Fd  *= tonemap( sphericalHarmonics(M.normal) );
+    #else
+    Fd *= envMap(M.normal, 0.8); // a roughness of 0.8 visually matches the factors returned by Unity's ShadeSH9
     #endif
     Fd  *= diffuseAO;
     Fd  *= (1.0 - E);

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -100,10 +100,12 @@ float4 pbr(const Material _mat) {
     Fr  *= specularAO(M, diffuseAO);
 
     float3 Fd = diffuseColor;
-    #if defined(UNITY_COMPILER_HLSL)
-    Fd *= ShadeSH9(half4(M.normal,1));
-    #elif defined(SCENE_SH_ARRAY)
+    #if defined(SCENE_SH_ARRAY)
     Fd  *= tonemap( sphericalHarmonics(M.normal) );
+    //#elif defined(UNITY_COMPILER_HLSL)
+    // Fd *= ShadeSH9(half4(M.normal,1));
+    #else
+    Fd *= envMap(M.normal, 0.8); // a roughness of 0.8 visually matches the factors returned by Unity's ShadeSH9
     #endif
     Fd  *= diffuseAO;
     Fd  *= (1.0 - E);


### PR DESCRIPTION
Currently, the PBR shader expects SCENE_SH_ARRAY (the spherical harmonics array) to be defined and will fail if not (the indirect diffuse component is broken).
An elegant fallback is to sample the environment at a high LOD level.
