### PR TITLE
Fixed Raymarching AO

### DIFF
--- a/lighting/common/specularAO.glsl
+++ b/lighting/common/specularAO.glsl
@@ -1,3 +1,6 @@
+// See section 4.10.2 in Sebastien Lagarde: Moving Frostbite to Physically Based Rendering 3.0
+// https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+
 #include "../../math/saturate.glsl"
 
 #if !defined(TARGET_MOBILE) && !defined(PLATFORM_RPI) && !defined(PLATFORM_WEBGL)

--- a/lighting/common/specularAO.hlsl
+++ b/lighting/common/specularAO.hlsl
@@ -1,3 +1,6 @@
+// See section 4.10.2 in Sebastien Lagarde: Moving Frostbite to Physically Based Rendering 3.0
+// https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+
 #if !defined(TARGET_MOBILE) && !defined(PLATFORM_RPI) && !defined(PLATFORM_WEBGL)
 #define IBL_SPECULAR_OCCLUSION
 #endif

--- a/lighting/fresnelReflection.glsl
+++ b/lighting/fresnelReflection.glsl
@@ -29,7 +29,7 @@ vec3 fresnelReflection(const in vec3 R, const in vec3 f0, const in float NoV) {
 
     vec3 reflectColor = vec3(0.0);
     #if defined(FRESNEL_REFLECTION_FNC)
-    reflection = FRESNEL_REFLECTION_FNC(R);
+    reflectColor = FRESNEL_REFLECTION_FNC(R);
     #else
     reflectColor = envMap(R, 1.0, 0.001);
     #endif
@@ -40,7 +40,7 @@ vec3 fresnelReflection(const in vec3 R, const in vec3 f0, const in float NoV) {
 vec3 fresnelReflection(const in vec3 R, const in vec3 Fr) {
     vec3 reflectColor = vec3(0.0);
     #if defined(FRESNEL_REFLECTION_FNC)
-    reflection = FRESNEL_REFLECTION_FNC(R);
+    reflectColor = FRESNEL_REFLECTION_FNC(R);
     #else
     reflectColor = envMap(R, 1.0, 0.001);
     #endif

--- a/lighting/fresnelReflection.hlsl
+++ b/lighting/fresnelReflection.hlsl
@@ -30,7 +30,7 @@ float3 fresnelReflection(const in float3 R, const in float3 f0, const in float N
 
     float3 reflectColor = float3(0.0, 0.0, 0.0);
 #if defined(FRESNEL_REFLECTION_FNC)
-    reflection = FRESNEL_REFLECTION_FNC(R);
+    reflectColor = FRESNEL_REFLECTION_FNC(R);
 #else
     reflectColor = envMap(R, 1.0, 0.001);
 #endif
@@ -42,7 +42,7 @@ float3 fresnelReflection(const in float3 R, const in float3 Fr)
 {
     float3 reflectColor = float3(0.0, 0.0, 0.0);
 #if defined(FRESNEL_REFLECTION_FNC)
-    reflection = FRESNEL_REFLECTION_FNC(R);
+    reflectColor = FRESNEL_REFLECTION_FNC(R);
 #else
     reflectColor = envMap(R, 1.0, 0.001);
 #endif

--- a/lighting/raymarch/ao.glsl
+++ b/lighting/raymarch/ao.glsl
@@ -3,7 +3,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: Calculare Ambient Occlusion
+description: Calculate Ambient Occlusion. See calcAO in https://www.shadertoy.com/view/lsKcDD
 use: <float> raymarchAO( in <vec3> pos, in <vec3> nor ) 
 examples:
     - /shaders/lighting_raymarching.frag
@@ -24,18 +24,18 @@ examples:
 #ifndef FNC_RAYMARCHAO
 #define FNC_RAYMARCHAO
 
-float raymarchAO( in vec3 pos, in vec3 nor ) {
+float raymarchAO(in vec3 pos, in vec3 nor)
+{
     float occ = 0.0;
     float sca = 1.0;
-    for( int i = 0; i < RAYMARCH_SAMPLES_AO; i++ ) {
-        float hr = 0.01 + 0.12 * float(i) * 0.2;
-        float dd = RAYMARCH_MAP_FNC( hr * nor + pos ).RAYMARCH_MAP_DISTANCE;
-        occ += (hr-dd)*sca;
-        sca *= 0.9;
-        if( occ > 0.35 ) 
-            break;
+    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++)
+    {
+        float h = 0.001 + 0.15 * float(i) / 4.0;
+        float d = RAYMARCH_MAP_FNC(pos + h * nor).RAYMARCH_MAP_DISTANCE;
+        occ += (h - d) * sca;
+        sca *= 0.95;
     }
-    return saturate( 1.0 - 3.0 * occ ) * (0.5+0.5*nor.y);
+    return clamp(1.0 - 1.5 * occ, 0.0, 1.0);
 }
 
 #endif

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: Calculare Ambient Occlusion
+description: Calculate Ambient Occlusion. See calcAO in https://www.shadertoy.com/view/lsKcDD
 use: <float> raymarchAO( in <float3> pos, in <float3> nor ) 
 */
 
@@ -21,18 +21,18 @@ use: <float> raymarchAO( in <float3> pos, in <float3> nor )
 #ifndef FNC_RAYMARCHAO
 #define FNC_RAYMARCHAO
 
-float raymarchAO( in float3 pos, in float3 nor ) {
+float raymarchAO(in float3 pos, in float3 nor)
+{
     float occ = 0.0;
     float sca = 1.0;
-    for( int i = 0; i < RAYMARCH_SAMPLES_AO; i++ ) {
-        float hr = 0.01 + 0.12 * float(i) * 0.2;
-        float dd = RAYMARCH_MAP_FNC( hr * nor + pos ).RAYMARCH_MAP_DISTANCE;
-        occ += (hr-dd)*sca;
-        sca *= 0.9;
-        if( occ > 0.35 ) 
-            break;
+    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++)
+    {
+        float h = 0.001 + 0.15 * float(i) / 4.0;
+        float d = RAYMARCH_MAP_FNC(pos + h * nor).RAYMARCH_MAP_DISTANCE;
+        occ += (h - d) * sca;
+        sca *= 0.95;
     }
-    return saturate( 1.0 - 3.0 * occ ) * (0.5+0.5*nor.y);
+    return clamp(1.0 - 1.5 * occ, 0.0, 1.0);
 }
 
 #endif


### PR DESCRIPTION
Replaced broken Raymarching AO implementation (HLSL and GLSL)

The new implementation is from IQ's Shadertoy [Soft Shadow Variation ](https://www.shadertoy.com/view/lsKcDD).

Bonus tracks:
* Fixed fresnelReflection with custom FRESNEL_REFLECTION_FNC
* Added link to specularAO

Before (notice the weird and unrealistic shadow at the bottom),
![Screenshot 2024-07-29 214652](https://github.com/user-attachments/assets/d9cba3ac-c8c6-4eaa-b15a-abea2d3b3dcc)

After
![Screenshot 2024-07-29 214718](https://github.com/user-attachments/assets/7d79b376-8c10-42f3-87d1-43bcf8a2e44d)
![Screenshot 2024-07-29 214749](https://github.com/user-attachments/assets/440558e1-f8ae-49e0-9a22-84d85554a60b)
