### PR TITLE
Added AOV output support to the Raymarching engine

### DIFF
--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -1,7 +1,8 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: Raymarching template where it needs to define a vec4 raymarchMap( in vec3 pos )
-use: <vec4> raymarch(<vec3> camera, <vec2> st)
+use: <vec4> raymarch(<vec3> cameraPosition, <vec3> lookAt, <vec2> st,
+    out <vec3> eyeDepth, out <vec3> worldPosition, out <vec3> worldNormal )
 options:
     - LIGHT_POSITION: in glslViewer is u_light
     - LIGHT_DIRECTION
@@ -38,26 +39,50 @@ license:
 
 #ifndef ENG_RAYMARCHING
 #define ENG_RAYMARCHING
-vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
+
+vec4 raymarch( vec3 camera, vec3 ta, vec2 st,
+    out float eyeDepth, out vec3 worldPos, out vec3 worldNormal) {
+
     mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
     float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    vec3 cameraForward = normalize(ta - camera);
     st.x = 1.0 - st.x;
 
 #if defined(RAYMARCH_MULTISAMPLE)
     vec4 color = vec4(0.0);
+    eyeDepth = 0;
+    worldPos = vec3(0.0);
+    worldNormal = vec3(0.0);
     vec2 pixel = 1.0/RESOLUTION;
     vec2 offset = rotate( vec2(0.5, 0.0), HALF_PI/4.);
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
         vec3 rd = ca * normalize(vec3((st + offset * pixel)*2.0-1.0, fov));
-        color += RAYMARCH_RENDER_FNC( camera, rd, ta );
+        float sampleDepth = 0;
+        vec3 sampleWorldPos = vec3(0.0);
+        vec3 sampleWorldNormal = vec3(0.0);
+        color += RAYMARCH_RENDER_FNC( camera, rd, cameraForward,
+            sampleDepth, sampleWorldPos, sampleWorldNormal );
+        eyeDepth += sampleDepth;
+        worldPos += sampleWorldPos;
+        worldNormal += sampleWorldNormal;
         offset = rotate(offset, HALF_PI);
     }
+    eyeDepth /= float(RAYMARCH_MULTISAMPLE);
+    worldPos /= float(RAYMARCH_MULTISAMPLE);
+    worldNormal /= float(RAYMARCH_MULTISAMPLE);
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
     vec3 rd = ca * normalize(vec3(st*2.0-1.0, fov));
-    return RAYMARCH_RENDER_FNC( camera, rd, ta );
+    return RAYMARCH_RENDER_FNC( camera, rd, cameraForward, eyeDepth, worldPos, worldNormal );
 #endif
+}
+
+vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
+    float depth = 0.0;
+    vec3 worldPos = vec3(0.0);
+    vec3 worldNormal = vec3(0.0);
+    return raymarch(camera, ta, st, depth, worldPos, worldNormal);
 }
 
 vec4 raymarch(vec3 camera, vec2 st) {

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -10,7 +10,7 @@ options:
     - RAYMARCH_MULTISAMPLE: null
     - RAYMARCH_BACKGROUND: default vec3(0.0)
     - RAYMARCH_CAMERA_MATRIX_FNC(RO, TA): default raymarchCamera(RO, TA)
-    - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD)
+    - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD, TA)
     - RESOLUTION: nan
 examples:
     - /shaders/lighting_raymarching.frag
@@ -50,13 +50,13 @@ vec4 raymarch(vec3 camera, vec3 ta, vec2 st) {
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
         vec3 rd = ca * normalize(vec3((st + offset * pixel)*2.0-1.0, fov));
-        color += RAYMARCH_RENDER_FNC( camera, rd);
+        color += RAYMARCH_RENDER_FNC( camera, rd, ta );
         offset = rotate(offset, HALF_PI);
     }
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
     vec3 rd = ca * normalize(vec3(st*2.0-1.0, fov));
-    return RAYMARCH_RENDER_FNC( camera, rd);
+    return RAYMARCH_RENDER_FNC( camera, rd, ta );
 #endif
 }
 

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -1,7 +1,8 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: Raymarching template where it needs to define a float4 raymarchMSap( in float3 pos )
-use: <float4> raymarch(<float3> camera, <float2> st)
+use: <float4> raymarch(<float3> cameraPosition, <float3> lookAt, <float2> st,
+    out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal )
 options:
     - LIGHT_POSITION: in glslViewer is u_light
     - LIGHT_DIRECTION
@@ -40,26 +41,49 @@ license:
 #ifndef ENG_RAYMARCH
 #define ENG_RAYMARCH
 
-float4 raymarch(float3 camera, float3 ta, float2 st) {
-    float3x3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
+float4 raymarch( float3 camera, float3 ta, float2 st,
+    out float eyeDepth, out float3 worldPos, out float3 worldNormal) {
+
+    mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
     float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
+    float3 cameraForward = normalize(ta - camera);
     st.x = 1.0 - st.x;
-    
+
 #if defined(RAYMARCH_MULTISAMPLE)
-    float4 color = float4(0.0, 0.0, 0.0, 0.0);
-    float2 pixel = 1.0/ RESOLUTION;
+    float4 color = float4(0.0);
+    eyeDepth = 0;
+    worldPos = float3(0.0);
+    worldNormal = float3(0.0);
+    float2 pixel = 1.0/RESOLUTION;
     float2 offset = rotate( float2(0.5, 0.0), HALF_PI/4.);
 
-    for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {    
-        float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, fov)) );
-        color += RAYMARCH_RENDER_FNC( camera, rd, ta );
+    for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
+        float3 rd = ca * normalize(float3((st + offset * pixel)*2.0-1.0, fov));
+        float sampleDepth = 0;
+        float3 sampleWorldPos = float3(0.0);
+        float3 sampleWorldNormal = float3(0.0);
+        color += RAYMARCH_RENDER_FNC( camera, rd, cameraForward,
+            sampleDepth, sampleWorldPos, sampleWorldNormal );
+        eyeDepth += sampleDepth;
+        worldPos += sampleWorldPos;
+        worldNormal += sampleWorldNormal;
         offset = rotate(offset, HALF_PI);
     }
+    eyeDepth /= float(RAYMARCH_MULTISAMPLE);
+    worldPos /= float(RAYMARCH_MULTISAMPLE);
+    worldNormal /= float(RAYMARCH_MULTISAMPLE);
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
-    float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, fov)));
-    return RAYMARCH_RENDER_FNC(camera, rd, ta);
+    float3 rd = ca * normalize(float3(st*2.0-1.0, fov));
+    return RAYMARCH_RENDER_FNC( camera, rd, cameraForward, eyeDepth, worldPos, worldNormal );
 #endif
+}
+
+float4 raymarch(float3 camera, float3 ta, float2 st) {
+    float depth = 0.0;
+    float3 worldPos = float3(0.0);
+    float3 worldNormal = float3(0.0);
+    return raymarch(camera, ta, st, depth, worldPos, worldNormal);
 }
 
 float4 raymarch(float3 camera, float2 st) {

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -10,7 +10,7 @@ options:
     - RAYMARCH_MULTISAMPLE: null
     - RAYMARCH_BACKGROUND: default float3(0.0)
     - RAYMARCH_CAMERA_MATRIX_FNC(RO, TA): default raymarchCamera(RO, TA)
-    - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD)
+    - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD, TA)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -52,13 +52,13 @@ float4 raymarch(float3 camera, float3 ta, float2 st) {
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {    
         float3 rd = mul(ca, normalize(float3( (st + offset * pixel)*2.0-1.0, fov)) );
-        color += RAYMARCH_RENDER_FNC( camera, rd);
+        color += RAYMARCH_RENDER_FNC( camera, rd, ta );
         offset = rotate(offset, HALF_PI);
     }
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
     float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, fov)));
-    return RAYMARCH_RENDER_FNC(camera, rd);
+    return RAYMARCH_RENDER_FNC(camera, rd, ta);
 #endif
 }
 

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -44,24 +44,24 @@ license:
 float4 raymarch( float3 camera, float3 ta, float2 st,
     out float eyeDepth, out float3 worldPos, out float3 worldNormal) {
 
-    mat3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
+    float3x3 ca = RAYMARCH_CAMERA_MATRIX_FNC(camera, ta);
     float fov = 1.0/tan(RAYMARCH_CAMERA_FOV*PI/180.0/2.0);
     float3 cameraForward = normalize(ta - camera);
     st.x = 1.0 - st.x;
 
 #if defined(RAYMARCH_MULTISAMPLE)
-    float4 color = float4(0.0);
+    float4 color = float4(0.0, 0.0, 0.0, 0.0);
     eyeDepth = 0;
-    worldPos = float3(0.0);
-    worldNormal = float3(0.0);
+    worldPos = float3(0.0,0.0, 0.0);
+    worldNormal = float3(0.0, 0.0, 0.0);
     float2 pixel = 1.0/RESOLUTION;
     float2 offset = rotate( float2(0.5, 0.0), HALF_PI/4.);
 
     for (int i = 0; i < RAYMARCH_MULTISAMPLE; i++) {
-        float3 rd = ca * normalize(float3((st + offset * pixel)*2.0-1.0, fov));
+        float3 rd = mul(ca, normalize(float3((st + offset * pixel)*2.0-1.0, fov)));
         float sampleDepth = 0;
-        float3 sampleWorldPos = float3(0.0);
-        float3 sampleWorldNormal = float3(0.0);
+        float3 sampleWorldPos = float3(0.0, 0.0, 0.0);
+        float3 sampleWorldNormal = float3(0.0, 0.0, 0.0);
         color += RAYMARCH_RENDER_FNC( camera, rd, cameraForward,
             sampleDepth, sampleWorldPos, sampleWorldNormal );
         eyeDepth += sampleDepth;
@@ -74,15 +74,15 @@ float4 raymarch( float3 camera, float3 ta, float2 st,
     worldNormal /= float(RAYMARCH_MULTISAMPLE);
     return color/float(RAYMARCH_MULTISAMPLE);
 #else
-    float3 rd = ca * normalize(float3(st*2.0-1.0, fov));
+    float3 rd = mul(ca, normalize(float3(st * 2.0 - 1.0, fov)));
     return RAYMARCH_RENDER_FNC( camera, rd, cameraForward, eyeDepth, worldPos, worldNormal );
 #endif
 }
 
 float4 raymarch(float3 camera, float3 ta, float2 st) {
     float depth = 0.0;
-    float3 worldPos = float3(0.0);
-    float3 worldNormal = float3(0.0);
+    float3 worldPos = float3(0.0, 0.0, 0.0);
+    float3 worldNormal = float3(0.0, 0.0, 0.0);
     return raymarch(camera, ta, st, depth, worldPos, worldNormal);
 }
 

--- a/lighting/raymarch/material.glsl
+++ b/lighting/raymarch/material.glsl
@@ -56,11 +56,11 @@ license:
 #ifndef FNC_RAYMARCHMATERIAL
 #define FNC_RAYMARCHMATERIAL
 
-vec3 raymarchDefaultMaterial(vec3 ray, vec3 position, vec3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
+vec4 raymarchDefaultMaterial(vec3 ray, vec3 position, vec3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
     vec3  env = RAYMARCH_AMBIENT;
 
     if ( sum(color) <= 0.0 ) 
-        return RAYMARCH_BACKGROUND;
+        return vec4(RAYMARCH_BACKGROUND, 0.0);
 
     vec3 ref = reflect( ray, normal );
     float occ = raymarchAO( position, normal );
@@ -88,10 +88,10 @@ vec3 raymarchDefaultMaterial(vec3 ray, vec3 position, vec3 normal, RAYMARCH_MAP_
     light += 0.50 * bac * occ * 0.25;
     light += 0.25 * fre * occ;
 
-    return RAYMARCH_MAP_MATERIAL_FNC(color) * light;
+    return vec4(RAYMARCH_MAP_MATERIAL_FNC(color) * light, 1.0);
 }
 
-vec3 raymarchMaterial(vec3 ray, vec3 position, vec3 normal, vec3 albedo) {
+vec4 raymarchMaterial(vec3 ray, vec3 position, vec3 normal, vec3 albedo) {
     return RAYMARCH_MATERIAL_FNC(ray, position, normal, albedo);
 }
 

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -53,11 +53,11 @@ license:
 #ifndef FNC_RAYMARCHMATERIAL
 #define FNC_RAYMARCHMATERIAL
 
-float3 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
+float4 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
     float3  env = RAYMARCH_AMBIENT;
 
     if ( sum(color) <= 0.0 ) 
-        return RAYMARCH_BACKGROUND;
+        return float4(RAYMARCH_BACKGROUND, 0.0);
 
     float3 ref = reflect( ray, normal );
     float occ = raymarchAO( position, normal );
@@ -85,10 +85,10 @@ float3 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMA
     light += 0.50 * bac * occ * 0.25;
     light += 0.25 * fre * occ;
 
-    return RAYMARCH_MAP_MATERIAL_FNC(color) * light;
+    return float4(RAYMARCH_MAP_MATERIAL_FNC(color) * light, 1.0);
 }
 
-float3 raymarchMaterial(float3 ray, float3 position, float3 normal, float3 albedo) {
+float4 raymarchMaterial(float3 ray, float3 position, float3 normal, float3 albedo) {
     return RAYMARCH_MATERIAL_FNC(ray, position, normal, albedo);
 }
 

--- a/lighting/raymarch/render.glsl
+++ b/lighting/raymarch/render.glsl
@@ -40,7 +40,7 @@ examples:
 #ifndef FNC_RAYMARCHDEFAULT
 #define FNC_RAYMARCHDEFAULT
 
-vec4 raymarchDefaultRender( in vec3 ray_origin, in vec3 ray_direction ) { 
+vec4 raymarchDefaultRender( in vec3 ray_origin, in vec3 ray_direction, vec3 ta ) { 
     vec3 col = vec3(0.0);
     
     RAYMARCHCAST_TYPE res = raymarchCast(ray_origin, ray_direction);
@@ -51,7 +51,11 @@ vec4 raymarchDefaultRender( in vec3 ray_origin, in vec3 ray_direction ) {
     col = raymarchMaterial(ray_direction, pos, nor, res.RAYMARCH_MAP_MATERIAL);
     col = raymarchFog(col, t, ray_origin, ray_direction);
 
-    return vec4( saturate(col), t );
+    // https://www.shadertoy.com/view/4tByz3
+    vec3 cameraForward = normalize(ta - ray_origin);
+    float depth = t * dot(ray_direction, cameraForward);
+
+    return vec4( col, depth );
 }
 
 #endif

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -38,11 +38,11 @@ options:
 #ifndef FNC_RAYMARCHDEFAULT
 #define FNC_RAYMARCHDEFAULT
 
-float4 raymarchDefaultRender( in float3 ray_origin, in float3 ray_direction, in float3 ta ) { 
+float4 raymarchDefaultRender(
     in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
     out float eyeDepth, out float3 worldPos, out float3 worldNormal ) { 
 
-    vec4 color = vec4(0.0);
+    float4 color = float4(0.0, 0.0, 0.0, 0.0);
     
     RAYMARCHCAST_TYPE res = raymarchCast(rayOrigin, rayDirection);
     float t = res.RAYMARCH_MAP_DISTANCE;

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -8,7 +8,8 @@
 /*
 contributors:  Inigo Quiles
 description: Default raymarching renderer
-use: <float4> raymarchDefaultRender( in <float3> ro, in <float3> rd ) 
+use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
+    out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
     - LIGHT_COLOR: float3(0.5) or u_lightColor in glslViewer
     - LIGHT_POSITION: float3(0.0, 10.0, -50.0) or u_light in GlslViewer
@@ -38,21 +39,23 @@ options:
 #define FNC_RAYMARCHDEFAULT
 
 float4 raymarchDefaultRender( in float3 ray_origin, in float3 ray_direction, in float3 ta ) { 
-    float3 col = float3(0.0, 0.0, 0.0);
+    in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
+    out float eyeDepth, out float3 worldPos, out float3 worldNormal ) { 
+
+    vec4 color = vec4(0.0);
     
-    RAYMARCHCAST_TYPE res = raymarchCast(ray_origin, ray_direction);
+    RAYMARCHCAST_TYPE res = raymarchCast(rayOrigin, rayDirection);
     float t = res.RAYMARCH_MAP_DISTANCE;
 
-    float3 pos = ray_origin + t * ray_direction;
-    float3 nor = raymarchNormal( pos );
-    col = raymarchMaterial(ray_direction, pos, nor, res.RAYMARCH_MAP_MATERIAL);
-    col = raymarchFog(col, t, ray_origin, ray_direction);
-    
-    // https://www.shadertoy.com/view/4tByz3
-    float3 cameraForward = normalize(ta - ray_origin);
-    float depth = t * dot(ray_direction, cameraForward);
-    
-    return float4(col, depth);
+    worldPos = rayOrigin + t * rayDirection;
+    worldNormal = raymarchNormal( worldPos );
+    color = raymarchMaterial(rayDirection, worldPos, worldNormal, res.RAYMARCH_MAP_MATERIAL);
+    color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
+
+    // Eye-space depth. See https://www.shadertoy.com/view/4tByz3
+    eyeDepth = t * dot(rayDirection, cameraForward);
+
+    return color;
 }
 
 #endif

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -37,7 +37,7 @@ options:
 #ifndef FNC_RAYMARCHDEFAULT
 #define FNC_RAYMARCHDEFAULT
 
-float4 raymarchDefaultRender( in float3 ray_origin, in float3 ray_direction ) { 
+float4 raymarchDefaultRender( in float3 ray_origin, in float3 ray_direction, in float3 ta ) { 
     float3 col = float3(0.0, 0.0, 0.0);
     
     RAYMARCHCAST_TYPE res = raymarchCast(ray_origin, ray_direction);
@@ -48,7 +48,11 @@ float4 raymarchDefaultRender( in float3 ray_origin, in float3 ray_direction ) {
     col = raymarchMaterial(ray_direction, pos, nor, res.RAYMARCH_MAP_MATERIAL);
     col = raymarchFog(col, t, ray_origin, ray_direction);
     
-    return float4( saturate(col), t );
+    // https://www.shadertoy.com/view/4tByz3
+    float3 cameraForward = normalize(ta - ray_origin);
+    float depth = t * dot(ray_direction, cameraForward);
+    
+    return float4(col, depth);
 }
 
 #endif


### PR DESCRIPTION
Added AOV (Arbitrary Output Variables) output support to the Raymarching engine.
These additional buffers are very useful for post-processing passes. And the good news: they come almost for free, as raymarching already provides us with this data!

We now have:

Color
![Screenshot 2024-07-30 172548](https://github.com/user-attachments/assets/88bd6a53-eec8-431d-9ad6-e547ee9429a2)

Alpha
![Screenshot 2024-07-30 172619](https://github.com/user-attachments/assets/347df661-8535-4d3c-858a-d29ad73db647)

Eye Depth
![Screenshot 2024-07-30 172534](https://github.com/user-attachments/assets/b9433c97-ce6e-43a9-b0fa-858b61b8299b)

World Position
![Screenshot 2024-07-30 172512](https://github.com/user-attachments/assets/b632f957-32de-4773-84a1-dda5532b33e3)

World Normals
![Screenshot 2024-07-30 172450](https://github.com/user-attachments/assets/3a197799-5277-486a-a85f-6e74c4e0e570)

And finally, to illustrate, some DOF fun using the Eye Depth AOV and Lygia's sample/dof

![Screenshot 2024-07-30 175913](https://github.com/user-attachments/assets/9e8906fd-4a17-48a0-9bb9-a3d3799d2d53)

