### PR TITLE
Overhaul of the Raymarching material system.

### DIFF
--- a/geometry/triangle/centroid.glsl
+++ b/geometry/triangle/centroid.glsl
@@ -1,4 +1,4 @@
-#include "triangle.hlsl"
+#include "triangle.glsl"
 
 /*
 contributors: Patricio Gonzalez Vivo

--- a/lighting/material.glsl
+++ b/lighting/material.glsl
@@ -26,6 +26,10 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
+#if !defined(MATERIAL_OPT_IN)
+#define RENDER_RAYMARCHING
+#endif
+
 #ifndef STR_MATERIAL
 #define STR_MATERIAL
 struct Material {
@@ -34,8 +38,11 @@ struct Material {
 
     vec3    position;       // world position of the surface
     vec3    normal;         // world normal of the surface
+
+#if defined(RENDER_RAYMARCHING)
     float   sdf;
     bool    valid;
+#endif
 
     #if defined(SCENE_BACK_SURFACE)
     vec3    normal_back;    // world normal of the back surface of the model

--- a/lighting/material.glsl
+++ b/lighting/material.glsl
@@ -48,7 +48,7 @@ struct Material {
     float   metallic;
     float   ambientOcclusion;   // default 1.0
 
-#if defined (SHADING_MODEL_CLEAR_COAT)
+#if defined(SHADING_MODEL_CLEAR_COAT)
     float   clearCoat;
     float   clearCoatRoughness;
     #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)

--- a/lighting/material.glsl
+++ b/lighting/material.glsl
@@ -35,6 +35,7 @@ struct Material {
     vec3    position;       // world position of the surface
     vec3    normal;         // world normal of the surface
     float   sdf;
+    bool    valid;
 
     #if defined(SCENE_BACK_SURFACE)
     vec3    normal_back;    // world normal of the back surface of the model

--- a/lighting/material.glsl
+++ b/lighting/material.glsl
@@ -14,11 +14,10 @@
 contributors: Patricio Gonzalez Vivo
 description: Generic Material Structure
 options:
-    - SURFACE_POSITION
-    - SHADING_SHADOWS
-    - MATERIAL_HAS_CLEAR_COAT
-    - MATERIAL_CLEARCOAT_ROUGHNESS
+    - SCENE_BACK_SURFACE
+    - SHADING_MODEL_CLEAR_COAT
     - MATERIAL_HAS_CLEAR_COAT_NORMAL
+    - SHADING_MODEL_IRIDESCENCE
     - SHADING_MODEL_SUBSURFACE
     - SHADING_MODEL_CLOTH
     - SHADING_MODEL_SPECULAR_GLOSSINESS
@@ -35,6 +34,7 @@ struct Material {
 
     vec3    position;       // world position of the surface
     vec3    normal;         // world normal of the surface
+    float   sdf;
 
     #if defined(SCENE_BACK_SURFACE)
     vec3    normal_back;    // world normal of the back surface of the model
@@ -46,15 +46,14 @@ struct Material {
     float   roughness;
     float   metallic;
     float   ambientOcclusion;   // default 1.0
-    // float   shadow;             // default 1.0
 
-// #if defined(MATERIAL_HAS_CLEAR_COAT)
+#if defined (SHADING_MODEL_CLEAR_COAT)
     float   clearCoat;
     float   clearCoatRoughness;
     #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     vec3    clearCoatNormal;    // default vec3(0.0, 0.0, 1.0);
     #endif
-// #endif
+#endif
 
 #if defined(SHADING_MODEL_IRIDESCENCE)
     float   thickness; // default to 300.0

--- a/lighting/material.hlsl
+++ b/lighting/material.hlsl
@@ -26,6 +26,10 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
+#if !defined(MATERIAL_OPT_IN)
+#define RENDER_RAYMARCHING
+#endif
+
 #ifndef STR_MATERIAL
 #define STR_MATERIAL
 struct Material
@@ -35,8 +39,11 @@ struct Material
 
     float3 position; // world position of the surface
     float3 normal;   // world normal of the surface
-    float  sdf;
-    bool   valid;
+
+#if defined(RENDER_RAYMARCHING)
+    float   sdf;
+    bool    valid;
+#endif
     
 #ifdef SCENE_BACK_SURFACE
     float3  normal_back;        // world normal of the back surface of the model

--- a/lighting/material.hlsl
+++ b/lighting/material.hlsl
@@ -36,6 +36,7 @@ struct Material
     float3 position; // world position of the surface
     float3 normal;   // world normal of the surface
     float  sdf;
+    bool   valid;
     
 #ifdef SCENE_BACK_SURFACE
     float3  normal_back;        // world normal of the back surface of the model

--- a/lighting/material.hlsl
+++ b/lighting/material.hlsl
@@ -14,11 +14,10 @@
 contributors: Patricio Gonzalez Vivo
 description: Generic Material Structure
 options:
-    - SURFACE_POSITION
-    - SHADING_SHADOWS
-    - MATERIAL_HAS_CLEAR_COAT
-    - MATERIAL_CLEARCOAT_ROUGHNESS
+    - SCENE_BACK_SURFACE
+    - SHADING_MODEL_CLEAR_COAT
     - MATERIAL_HAS_CLEAR_COAT_NORMAL
+    - SHADING_MODEL_IRIDESCENCE
     - SHADING_MODEL_SUBSURFACE
     - SHADING_MODEL_CLOTH
     - SHADING_MODEL_SPECULAR_GLOSSINESS
@@ -29,30 +28,33 @@ license:
 
 #ifndef STR_MATERIAL
 #define STR_MATERIAL
-struct Material {
-    float4  albedo;
-    float3  emissive;
+struct Material
+{
+    float4 albedo;
+    float3 emissive;
 
-    float3  position;           // world position of the surface
-    float3  normal;             // world normal of the surface
-
-    #if defined(SCENE_BACK_SURFACE)
+    float3 position; // world position of the surface
+    float3 normal;   // world normal of the surface
+    float  sdf;
+    
+#ifdef SCENE_BACK_SURFACE
     float3  normal_back;        // world normal of the back surface of the model
-    #endif
+#endif
     
-    float3  ior;                // Index of Refraction
-    float3  f0;                 // reflectance at 0 degree 
+    float3 ior; // Index of Refraction
+    float3 f0;  // reflectance at 0 degree 
     
-    float   roughness;
-    float   metallic;
-    float   ambientOcclusion;   // default 1.0
-    // float   shadow;             // default 1.0
+    float roughness;
+    float metallic;
+    float ambientOcclusion; // default 1.0
 
+#if defined(SHADING_MODEL_CLEAR_COAT)
     float   clearCoat;
     float   clearCoatRoughness;
-    #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
+    #if defined (MATERIAL_HAS_CLEAR_COAT_NORMAL)
     float3  clearCoatNormal;    // default float3(0.0, 0.0, 1.0)
     #endif
+#endif
 
 #if defined(SHADING_MODEL_IRIDESCENCE)
     float   thickness; // default to 300.0

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -117,14 +117,14 @@ void materialNew(out Material _mat) {
 #endif
 
 #if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
-    vec3    specularColor;
-    float   glossiness;
+    _mat.specularColor = vec3(0.04, 0.04, 0.04);
+    _mat.glossiness = 0.5;
 #endif
 
     // Cache
-    vec3    V;
-    vec3    R;
-    float   NoV;
+    _mat.V = vec3(0.0);
+    _mat.R = vec3(0.0);
+    _mat.NoV = 0.0;
 }
 
 Material materialNew() {

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -44,6 +44,7 @@ void materialNew(out Material _mat) {
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
     _mat.sdf                = 0.0;
+    _mat.valid              = true;
 
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         vec4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);
@@ -129,6 +130,13 @@ void materialNew(out Material _mat) {
 Material materialNew() {
     Material mat;
     materialNew(mat);
+    return mat;
+}
+
+Material materialNew(float3 albedo, float sdf) {
+    Material mat = materialNew();
+    mat.albedo.rgb = albedo;
+    mat.sdf = sdf;
     return mat;
 }
 

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -133,14 +133,14 @@ Material materialNew() {
     return mat;
 }
 
-Material materialNew(float3 albedo, float sdf) {
+Material materialNew(vec3 albedo, float sdf) {
     Material mat = materialNew();
     mat.albedo.rgb = albedo;
     mat.sdf = sdf;
     return mat;
 }
 
-Material materialNew(float3 albedo, float metallic, float roughness, float sdf) {
+Material materialNew(vec3 albedo, float metallic, float roughness, float sdf) {
     Material mat = materialNew();
     mat.albedo.rgb = albedo;
     mat.metallic = metallic;

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -43,8 +43,11 @@ void materialNew(out Material _mat) {
     // Surface data
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
+
+#if defined(RENDER_RAYMARCHING)
     _mat.sdf                = 0.0;
     _mat.valid              = true;
+#endif
 
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         vec4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -20,12 +20,13 @@ use:
     - <material> materialNew()
 options:
     - SURFACE_POSITION
-    - SHADING_SHADOWS
-    - MATERIAL_HAS_CLEAR_COAT
-    - MATERIAL_CLEARCOAT_ROUGHNESS
+    - SCENE_BACK_SURFACE
+    - SHADING_MODEL_CLEAR_COAT
     - MATERIAL_HAS_CLEAR_COAT_NORMAL
+    - SHADING_MODEL_IRIDESCENCE
     - SHADING_MODEL_SUBSURFACE
     - SHADING_MODEL_CLOTH
+    - SHADING_MODEL_SPECULAR_GLOSSINESS
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -140,4 +140,13 @@ Material materialNew(float3 albedo, float sdf) {
     return mat;
 }
 
+Material materialNew(float3 albedo, float metallic, float roughness, float sdf) {
+    Material mat = materialNew();
+    mat.albedo.rgb = albedo;
+    mat.metallic = metallic;
+    mat.roughness = roughness;
+    mat.sdf = sdf;
+    return mat;
+}
+
 #endif

--- a/lighting/material/new.glsl
+++ b/lighting/material/new.glsl
@@ -8,7 +8,6 @@
 #include "shininess.glsl"
 
 #include "../material.glsl"
-// #include "../shadow.glsl"
 #include "../ior.glsl"
 #include "../../sampler.glsl"
 
@@ -43,6 +42,7 @@ void materialNew(out Material _mat) {
     // Surface data
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
+    _mat.sdf                = 0.0;
 
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         vec4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);
@@ -63,21 +63,16 @@ void materialNew(out Material _mat) {
     _mat.ior                = vec3(IOR_GLASS_RGB);      // Index of Refraction
     _mat.f0                 = vec3(0.04, 0.04, 0.04);   // reflectance at 0 degree
 
-    // Shade
     _mat.ambientOcclusion   = materialOcclusion();
 
-    // _mat.shadow             = SHADOW_INIT;
-
-    // Clear Coat Model
-// #if defined(MATERIAL_HAS_CLEAR_COAT)
+#if defined (SHADING_MODEL_CLEAR_COAT)
     _mat.clearCoat          = 0.0;
     _mat.clearCoatRoughness = 0.01;
-#if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
+    #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     _mat.clearCoatNormal    = vec3(0.0, 0.0, 1.0);
+    #endif
 #endif
-// #endif
 
-    // SubSurface Model
 #if defined(SHADING_MODEL_IRIDESCENCE)
     _mat.thickness          = 300.0;
 #endif
@@ -111,16 +106,23 @@ void materialNew(out Material _mat) {
         // This is pretty much of a hack by overwriting the absorption to the thinkness
         _mat.subsurfaceThickness = max(Do - Di, 0.005) * 30.0;
     }
-
-
     #endif
 
 #endif
 
-    // Cloth Model
 #if defined(SHADING_MODEL_CLOTH)
     _mat.sheenColor         = sqrt(_mat.albedo.rgb);
 #endif
+
+#if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
+    vec3    specularColor;
+    float   glossiness;
+#endif
+
+    // Cache
+    vec3    V;
+    vec3    R;
+    float   NoV;
 }
 
 Material materialNew() {

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -44,6 +44,7 @@ void materialNew(out Material _mat) {
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
     _mat.sdf                = 0.0;
+    _mat.valid              = true;
     
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         float4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);
@@ -129,6 +130,13 @@ void materialNew(out Material _mat) {
 Material materialNew() {
     Material mat;
     materialNew(mat);
+    return mat;
+}
+
+Material materialNew(float3 albedo, float sdf) {
+    Material mat = materialNew();
+    mat.albedo.rgb = albedo;
+    mat.sdf = sdf;
     return mat;
 }
 

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -43,8 +43,11 @@ void materialNew(out Material _mat) {
     // Surface data
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
+
+#if defined(RENDER_RAYMARCHING)
     _mat.sdf                = 0.0;
     _mat.valid              = true;
+#endif
     
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         float4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -140,4 +140,14 @@ Material materialNew(float3 albedo, float sdf) {
     return mat;
 }
 
+Material materialNew(float3 albedo, float metallic, float roughness, float sdf)
+{
+    Material mat = materialNew();
+    mat.albedo.rgb = albedo;
+    mat.metallic = metallic;
+    mat.roughness = roughness;
+    mat.sdf = sdf;
+    return mat;
+}
+
 #endif

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -19,13 +19,13 @@ use:
     - void materialNew(out <material> _mat)
     - <material> materialNew()
 options:
-    - SURFACE_POSITION
-    - SHADING_SHADOWS
-    - MATERIAL_HAS_CLEAR_COAT
-    - MATERIAL_CLEARCOAT_ROUGHNESS
+    - SCENE_BACK_SURFACE
+    - SHADING_MODEL_CLEAR_COAT
     - MATERIAL_HAS_CLEAR_COAT_NORMAL
+    - SHADING_MODEL_IRIDESCENCE
     - SHADING_MODEL_SUBSURFACE
     - SHADING_MODEL_CLOTH
+    - SHADING_MODEL_SPECULAR_GLOSSINESS
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -42,7 +42,8 @@ void materialNew(out Material _mat) {
     // Surface data
     _mat.position           = (SURFACE_POSITION).xyz;
     _mat.normal             = materialNormal();
-
+    _mat.sdf                = 0.0;
+    
     #if defined(SCENE_BACK_SURFACE) && defined(RESOLUTION)
         float4 back_surface       = SAMPLER_FNC(SCENE_BACK_SURFACE, gl_FragCoord.xy / RESOLUTION);
         _mat.normal_back        = back_surface.xyz;
@@ -62,19 +63,16 @@ void materialNew(out Material _mat) {
     _mat.ior                = float3(IOR_GLASS_RGB);      // Index of Refraction
     _mat.f0                 = float3(0.04, 0.04, 0.04); // reflectance at 0 degree
 
-    // Shade
     _mat.ambientOcclusion   = materialOcclusion();
 
-    // _mat.shadow             = SHADOW_INIT;
-
-    // Clear Coat Model
+#if defined(SHADING_MODEL_CLEAR_COAT)
     _mat.clearCoat          = 0.0;
     _mat.clearCoatRoughness = 0.01;
-#if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
+    #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     _mat.clearCoatNormal    = float3(0.0, 0.0, 1.0);
+    #endif
 #endif
 
-    // SubSurface Model
 #if defined(SHADING_MODEL_IRIDESCENCE)
     _mat.thickness          = 300.0;
 #endif
@@ -108,17 +106,20 @@ void materialNew(out Material _mat) {
         // This is pretty much of a hack by overwriting the absorption to the thinkness
         _mat.subsurfaceThickness = max(Do - Di, 0.005) * 30.0;
     }
-
-
     #endif
 
 #endif
     
-    // Cloth Model
 #if defined(SHADING_MODEL_CLOTH)
     _mat.sheenColor         = sqrt(_mat.albedo.rgb);
 #endif
-
+    
+#if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
+    float3  specularColor;
+    float   glossiness;
+#endif
+   
+    // Cache
     _mat.V                  = float3(0.0, 0.0, 0.0);
     _mat.R                  = float3(0.0, 0.0, 0.0);
     _mat.NoV                = 0;

--- a/lighting/material/new.hlsl
+++ b/lighting/material/new.hlsl
@@ -19,6 +19,7 @@ use:
     - void materialNew(out <material> _mat)
     - <material> materialNew()
 options:
+    - SURFACE_POSITION
     - SCENE_BACK_SURFACE
     - SHADING_MODEL_CLEAR_COAT
     - MATERIAL_HAS_CLEAR_COAT_NORMAL

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -52,7 +52,7 @@ vec4 pbr(const in Material _mat) {
 
     // Cached
     Material M  = _mat;
-    if (length(M.V) == 0) {
+    if (length(M.V) == 0.0) {
         M.V         = normalize(CAMERA_POSITION - M.position);  // View
     }
     M.NoV       = dot(M.normal, M.V);                       // Normal . View

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -52,7 +52,7 @@ vec4 pbr(const in Material _mat) {
 
     // Cached
     Material M  = _mat;
-    if (sum(M.V) == 0) {
+    if (length(M.V) == 0) {
         M.V         = normalize(CAMERA_POSITION - M.position);  // View
     }
     M.NoV       = dot(M.normal, M.V);                       // Normal . View

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -52,7 +52,9 @@ vec4 pbr(const in Material _mat) {
 
     // Cached
     Material M  = _mat;
-    M.V         = normalize(CAMERA_POSITION - M.position);  // View
+    if (sum(M.V) == 0) {
+        M.V         = normalize(CAMERA_POSITION - M.position);  // View
+    }
     M.NoV       = dot(M.normal, M.V);                       // Normal . View
     M.R         = reflection(M.V, M.normal, M.roughness);   // Reflection
 

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -52,7 +52,7 @@ vec4 pbr(const in Material _mat) {
 
     // Cached
     Material M  = _mat;
-    if (length(M.V) == 0.0) {
+    if (M.V.x != 0.0 && M.V.y != 0.0 & M.V.z != 0.0) {
         M.V         = normalize(CAMERA_POSITION - M.position);  // View
     }
     M.NoV       = dot(M.normal, M.V);                       // Normal . View

--- a/lighting/pbr.glsl
+++ b/lighting/pbr.glsl
@@ -52,7 +52,7 @@ vec4 pbr(const in Material _mat) {
 
     // Cached
     Material M  = _mat;
-    if (M.V.x != 0.0 && M.V.y != 0.0 & M.V.z != 0.0) {
+    if (M.V.x != 0.0 && M.V.y != 0.0 && M.V.z != 0.0) {
         M.V         = normalize(CAMERA_POSITION - M.position);  // View
     }
     M.NoV       = dot(M.normal, M.V);                       // Normal . View

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -27,7 +27,6 @@
 #define IBL_LUMINANCE   1.0
 #endif
 
-#include "../math/sum.hlsl"
 #include "../color/tonemap.hlsl"
 
 #include "material.hlsl"
@@ -71,7 +70,7 @@ float4 pbr(const Material _mat) {
 
     // Cached
     Material M = _mat;
-    if (sum(M.V) == 0) {
+    if (length(M.V) == 0) {
         M.V = normalize(CAMERA_POSITION - M.position); // View
     }
     M.NoV = dot(M.normal, M.V); // Normal . View

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -71,8 +71,7 @@ float4 pbr(const Material _mat) {
 
     // Cached
     Material M = _mat;
-    if (sum(M.V) == 0)
-    {
+    if (sum(M.V) == 0) {
         M.V = normalize(CAMERA_POSITION - M.position); // View
     }
     M.NoV = dot(M.normal, M.V); // Normal . View

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -70,7 +70,7 @@ float4 pbr(const Material _mat) {
 
     // Cached
     Material M = _mat;
-    if (length(M.V) == 0) {
+    if (M.V.x != 0.0 && M.V.y != 0.0 & M.V.z != 0.0) {
         M.V = normalize(CAMERA_POSITION - M.position); // View
     }
     M.NoV = dot(M.normal, M.V); // Normal . View

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -70,7 +70,7 @@ float4 pbr(const Material _mat) {
 
     // Cached
     Material M = _mat;
-    if (M.V.x != 0.0 && M.V.y != 0.0 & M.V.z != 0.0) {
+    if (M.V.x != 0.0 && M.V.y != 0.0 && M.V.z != 0.0) {
         M.V = normalize(CAMERA_POSITION - M.position); // View
     }
     M.NoV = dot(M.normal, M.V); // Normal . View

--- a/lighting/pbr.hlsl
+++ b/lighting/pbr.hlsl
@@ -27,6 +27,7 @@
 #define IBL_LUMINANCE   1.0
 #endif
 
+#include "../math/sum.hlsl"
 #include "../color/tonemap.hlsl"
 
 #include "material.hlsl"
@@ -70,7 +71,10 @@ float4 pbr(const Material _mat) {
 
     // Cached
     Material M = _mat;
-    M.V = normalize(CAMERA_POSITION - M.position); // View
+    if (sum(M.V) == 0)
+    {
+        M.V = normalize(CAMERA_POSITION - M.position); // View
+    }
     M.NoV = dot(M.normal, M.V); // Normal . View
     M.R = reflection(M.V, M.normal, M.roughness); // Reflection
 

--- a/lighting/pbrClearCoat.glsl
+++ b/lighting/pbrClearCoat.glsl
@@ -1,3 +1,7 @@
+#ifndef SHADING_MODEL_CLEAR_COAT
+#define SHADING_MODEL_CLEAR_COAT
+#endif
+
 #include "../math/saturate.glsl"
 #include "../color/tonemap.glsl"
 

--- a/lighting/pbrClearCoat.hlsl
+++ b/lighting/pbrClearCoat.hlsl
@@ -1,3 +1,7 @@
+#ifndef SHADING_MODEL_CLEAR_COAT
+#define SHADING_MODEL_CLEAR_COAT
+#endif
+
 #include "../color/tonemap.hlsl"
 #include "material.hlsl"
 #include "fresnelReflection.hlsl"

--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -4,15 +4,9 @@ description: Raymarching template where it needs to define a vec4 raymarchMap( i
 use: <vec4> raymarch(<vec3> cameraPosition, <vec3> lookAt, <vec2> st,
     out <vec3> eyeDepth, out <vec3> worldPosition, out <vec3> worldNormal )
 options:
-    - LIGHT_POSITION: in glslViewer is u_light
-    - LIGHT_DIRECTION
-    - LIGHT_COLOR: in glslViewer is u_lightColor
-    - RAYMARCH_AMBIENT: defualt vec3(1.0)
-    - RAYMARCH_MULTISAMPLE: null
-    - RAYMARCH_BACKGROUND: default vec3(0.0)
     - RAYMARCH_CAMERA_MATRIX_FNC(RO, TA): default raymarchCamera(RO, TA)
     - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD, TA)
-    - RESOLUTION: nan
+    - RAYMARCH_CAMERA_FOV
 examples:
     - /shaders/lighting_raymarching.frag
 license:

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -4,14 +4,9 @@ description: Raymarching template where it needs to define a float4 raymarchMSap
 use: <float4> raymarch(<float3> cameraPosition, <float3> lookAt, <float2> st,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal )
 options:
-    - LIGHT_POSITION: in glslViewer is u_light
-    - LIGHT_DIRECTION
-    - LIGHT_COLOR: in glslViewer is u_lightColor
-    - RAYMARCH_AMBIENT: defualt float3(1.0)
-    - RAYMARCH_MULTISAMPLE: null
-    - RAYMARCH_BACKGROUND: default float3(0.0)
     - RAYMARCH_CAMERA_MATRIX_FNC(RO, TA): default raymarchCamera(RO, TA)
     - RAYMARCH_RENDER_FNC(RO, RD): default raymarchDefaultRender(RO, RD, TA)
+    - RAYMARCH_CAMERA_FOV
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/lighting/raymarch/ao.glsl
+++ b/lighting/raymarch/ao.glsl
@@ -13,14 +13,6 @@ examples:
 #define RAYMARCH_SAMPLES_AO 5
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHAO
 #define FNC_RAYMARCHAO
 
@@ -28,10 +20,9 @@ float raymarchAO(in vec3 pos, in vec3 nor)
 {
     float occ = 0.0;
     float sca = 1.0;
-    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++)
-    {
+    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++) {
         float h = 0.001 + 0.15 * float(i) / 4.0;
-        float d = RAYMARCH_MAP_FNC(pos + h * nor).RAYMARCH_MAP_DISTANCE;
+        float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
         sca *= 0.95;
     }

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -17,8 +17,7 @@ float raymarchAO(in float3 pos, in float3 nor)
 {
     float occ = 0.0;
     float sca = 1.0;
-    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++)
-    {
+    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++) {
         float h = 0.001 + 0.15 * float(i) / 4.0;
         float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -10,14 +10,6 @@ use: <float> raymarchAO( in <float3> pos, in <float3> nor )
 #define RAYMARCH_SAMPLES_AO 5
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHAO
 #define FNC_RAYMARCHAO
 
@@ -28,7 +20,7 @@ float raymarchAO(in float3 pos, in float3 nor)
     for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++)
     {
         float h = 0.001 + 0.15 * float(i) / 4.0;
-        float d = RAYMARCH_MAP_FNC(pos + h * nor).RAYMARCH_MAP_DISTANCE;
+        float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
         sca *= 0.95;
     }

--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -1,5 +1,5 @@
 #include "map.glsl"
-#include "../material/new.hlsl"
+#include "../material/new.glsl"
 
 /*
 contributors:  Inigo Quiles
@@ -26,7 +26,7 @@ use: <float> castRay( in <vec3> pos, in <vec3> nor )
 #ifndef FNC_RAYMARCHCAST
 #define FNC_RAYMARCHCAST
 
-RAYMARCH_MAP_TYPE raymarchCast( in vec3 ro, in vec3 rd ) {
+Material raymarchCast( in vec3 ro, in vec3 rd ) {
     float tmin = RAYMARCH_MIN_DIST;
     float tmax = RAYMARCH_MAX_DIST;
    

--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -1,4 +1,5 @@
 #include "map.glsl"
+#include "../material/new.hlsl"
 
 /*
 contributors:  Inigo Quiles
@@ -22,26 +23,6 @@ use: <float> castRay( in <vec3> pos, in <vec3> nor )
 #define RAYMARCH_MIN_HIT_DIST 0.00001 * t
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_TYPE
-#define RAYMARCH_MAP_TYPE vec4
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_TYPE
-#define RAYMARCH_MAP_MATERIAL_TYPE vec3
-#endif
-
 #ifndef FNC_RAYMARCHCAST
 #define FNC_RAYMARCHCAST
 
@@ -56,21 +37,23 @@ RAYMARCH_MAP_TYPE raymarchCast( in vec3 ro, in vec3 rd ) {
 // #endif
     
     float t = tmin;
-    RAYMARCH_MAP_MATERIAL_TYPE m = RAYMARCH_MAP_MATERIAL_TYPE(-1.0);
-    for ( int i = 0; i < RAYMARCH_SAMPLES; i++ ) {
-        RAYMARCH_MAP_TYPE res = RAYMARCH_MAP_FNC( ro + rd * t );
-        if ( res.RAYMARCH_MAP_DISTANCE < RAYMARCH_MIN_HIT_DIST || t > tmax ) 
+    Material m = materialNew();
+    m.valid = false;
+    for (int i = 0; i < RAYMARCH_SAMPLES; i++) {
+        Material res = RAYMARCH_MAP_FNC(ro + rd * t);
+        if (res.sdf < RAYMARCH_MIN_HIT_DIST || t > tmax) 
             break;
-        t += res.RAYMARCH_MAP_DISTANCE;
-        m = res.RAYMARCH_MAP_MATERIAL;
+        m = res;
+        t += res.sdf;
     }
 
     #if defined(RAYMARCH_BACKGROUND) || defined(RAYMARCH_FLOOR)
-    if ( t > tmax ) 
-        m = RAYMARCH_MAP_MATERIAL_TYPE(-1.0);
+    if ( t > tmax )
+        m.valid = false;
     #endif
 
-    return RAYMARCH_MAP_TYPE( m, t );
+    m.sdf = t;
+    return m;
 }
 
 #endif

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -39,8 +39,7 @@ Material raymarchCast( in float3 ro, in float3 rd ) {
     float t = tmin;
     Material m = materialNew();
     m.valid = false;
-    for (int i = 0; i < RAYMARCH_SAMPLES; i++)
-    {
+    for (int i = 0; i < RAYMARCH_SAMPLES; i++) {
         Material res = RAYMARCH_MAP_FNC(ro + rd * t);
         if (res.sdf < RAYMARCH_MIN_HIT_DIST || t > tmax) 
             break;

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -1,4 +1,5 @@
 #include "map.hlsl"
+#include "../material/new.hlsl"
 
 /*
 contributors:  Inigo Quiles
@@ -22,30 +23,10 @@ use: <float> castRay( in <float3> pos, in <float3> nor )
 #define RAYMARCH_MIN_HIT_DIST 0.00001 * t
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_TYPE
-#define RAYMARCH_MAP_TYPE float4
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_TYPE
-#define RAYMARCH_MAP_MATERIAL_TYPE float3
-#endif
-
 #ifndef FNC_RAYMARCHCAST
 #define FNC_RAYMARCHCAST
 
-RAYMARCH_MAP_TYPE raymarchCast( in float3 ro, in float3 rd ) {
+Material raymarchCast( in float3 ro, in float3 rd ) {
     float tmin = RAYMARCH_MIN_DIST;
     float tmax = RAYMARCH_MAX_DIST;
    
@@ -56,22 +37,24 @@ RAYMARCH_MAP_TYPE raymarchCast( in float3 ro, in float3 rd ) {
 // #endif
     
     float t = tmin;
-    RAYMARCH_MAP_MATERIAL_TYPE m = RAYMARCH_MAP_MATERIAL_TYPE(-1.0, -1.0, -1.0);
+    Material m = materialNew();
+    m.valid = false;
     for (int i = 0; i < RAYMARCH_SAMPLES; i++)
     {
-        RAYMARCH_MAP_TYPE res = RAYMARCH_MAP_FNC(ro + rd * t);
-        if (res.RAYMARCH_MAP_DISTANCE < RAYMARCH_MIN_HIT_DIST || t > tmax) 
+        Material res = RAYMARCH_MAP_FNC(ro + rd * t);
+        if (res.sdf < RAYMARCH_MIN_HIT_DIST || t > tmax) 
             break;
-        t += res.RAYMARCH_MAP_DISTANCE;
-        m = res.RAYMARCH_MAP_MATERIAL;
+        m = res;
+        t += res.sdf;
     }
 
     #if defined(RAYMARCH_BACKGROUND) || defined(RAYMARCH_FLOOR)
-    if ( t > tmax ) 
-        m = RAYMARCH_MAP_MATERIAL_TYPE(-1.0, -1.0, -1.0);
+    if ( t > tmax )
+        m.valid = false;
     #endif
 
-    return RAYMARCH_MAP_TYPE(m, t);
+    m.sdf = t;
+    return m;
 }
 
 #endif

--- a/lighting/raymarch/map.glsl
+++ b/lighting/raymarch/map.glsl
@@ -1,4 +1,4 @@
-#include "../material.hlsl"
+#include "../material.glsl"
 
 /*
 contributors:  Inigo Quiles
@@ -15,6 +15,6 @@ examples:
 #ifndef FNC_RAYMARCHMAP
 #define FNC_RAYMARCHMAP
 
-RAYMARCH_MAP_TYPE RAYMARCH_MAP_FNC( in vec3 pos );
+Material RAYMARCH_MAP_FNC( in vec3 pos );
 
 #endif

--- a/lighting/raymarch/map.glsl
+++ b/lighting/raymarch/map.glsl
@@ -1,3 +1,5 @@
+#include "../material.hlsl"
+
 /*
 contributors:  Inigo Quiles
 description: Map of SDF functions to be declare
@@ -7,19 +9,7 @@ examples:
 */
 
 #ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_TYPE
-#define RAYMARCH_MAP_TYPE vec4
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
+#define RAYMARCH_MAP_FNC raymarchMap
 #endif
 
 #ifndef FNC_RAYMARCHMAP

--- a/lighting/raymarch/map.hlsl
+++ b/lighting/raymarch/map.hlsl
@@ -1,3 +1,5 @@
+#include "../material.hlsl"
+
 /*
 contributors:  Inigo Quiles
 description: Map of SDF functions to be declare
@@ -5,11 +7,7 @@ use: <float4> raymarchMap( in <float3> pos )
 */
 
 #ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_TYPE
-#define RAYMARCH_MAP_TYPE float4
+#define RAYMARCH_MAP_FNC raymarchMap
 #endif
 
 #ifndef RAYMARCH_MAP_DISTANCE
@@ -23,6 +21,6 @@ use: <float4> raymarchMap( in <float3> pos )
 #ifndef FNC_RAYMARCHMAP
 #define FNC_RAYMARCHMAP
 
-RAYMARCH_MAP_TYPE RAYMARCH_MAP_FNC( in float3 pos );
+Material RAYMARCH_MAP_FNC( in float3 pos );
 
 #endif

--- a/lighting/raymarch/map.hlsl
+++ b/lighting/raymarch/map.hlsl
@@ -10,14 +10,6 @@ use: <float4> raymarchMap( in <float3> pos )
 #define RAYMARCH_MAP_FNC raymarchMap
 #endif
 
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
-#endif
-
 #ifndef FNC_RAYMARCHMAP
 #define FNC_RAYMARCHMAP
 

--- a/lighting/raymarch/material.glsl
+++ b/lighting/raymarch/material.glsl
@@ -33,7 +33,7 @@ license:
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT vec3(0.0, 0.0, 0.0)
+#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_MATERIAL_FNC

--- a/lighting/raymarch/material.glsl
+++ b/lighting/raymarch/material.glsl
@@ -33,7 +33,7 @@ license:
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
+#define RAYMARCH_AMBIENT vec3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_MATERIAL_FNC
@@ -43,7 +43,7 @@ license:
 #ifndef FNC_RAYMARCHMATERIAL
 #define FNC_RAYMARCHMATERIAL
 
-vec4 raymarchDefaultMaterial(vec3 ray, vec3 position, vec3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
+vec4 raymarchDefaultMaterial(Material m) {
     vec3  env = RAYMARCH_AMBIENT;
 
     vec3 ref = reflect(-m.V, m.normal);

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -30,7 +30,7 @@ license:
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT float3(0.0, 0.0, 0.0)
+#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_MATERIAL_FNC

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -27,37 +27,32 @@ license:
 #endif
 
 #ifndef LIGHT_COLOR
-#define LIGHT_COLOR float3(0.5, 0.5, 0.5)
+#define LIGHT_COLOR float3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
+#define RAYMARCH_AMBIENT float3(0.0, 0.0, 0.0)
 #endif
 
 #ifndef RAYMARCH_BACKGROUND
-#define RAYMARCH_BACKGROUND float3(0.0, 1.0, 1.0)
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_TYPE
-#define RAYMARCH_MAP_MATERIAL_TYPE float3
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_FNC
-#define RAYMARCH_MAP_MATERIAL_FNC 
+#define RAYMARCH_BACKGROUND float3(0.0, 0.0, 0.0)
 #endif
 
 #ifndef RAYMARCH_MATERIAL_FNC
-#define RAYMARCH_MATERIAL_FNC(RAY, POSITION, NORMAL, ALBEDO) raymarchDefaultMaterial(RAY, POSITION, NORMAL, ALBEDO)
+#define RAYMARCH_MATERIAL_FNC raymarchDefaultMaterial
 #endif
 
 #ifndef FNC_RAYMARCHMATERIAL
 #define FNC_RAYMARCHMATERIAL
 
-float4 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMARCH_MAP_MATERIAL_TYPE color) {
+Material raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, Material material) {
     float3  env = RAYMARCH_AMBIENT;
 
-    if ( sum(color) <= 0.0 ) 
-        return float4(RAYMARCH_BACKGROUND, 0.0);
+    if (!material.valid)
+    {
+        material.albedo = float4(RAYMARCH_BACKGROUND, 0.0);
+        return material;
+    }
 
     float3 ref = reflect( ray, normal );
     float occ = raymarchAO( position, normal );
@@ -85,50 +80,9 @@ float4 raymarchDefaultMaterial(float3 ray, float3 position, float3 normal, RAYMA
     light += 0.50 * bac * occ * 0.25;
     light += 0.25 * fre * occ;
 
-    return float4(RAYMARCH_MAP_MATERIAL_FNC(color) * light, 1.0);
+    material.albedo.rgb *= light;
+    
+    return material;
 }
-
-float4 raymarchMaterial(float3 ray, float3 position, float3 normal, float3 albedo) {
-    return RAYMARCH_MATERIAL_FNC(ray, position, normal, albedo);
-}
-
-#if defined(STR_MATERIAL)
-void raymarchMaterial( in float3 ro, in float3 rd, inout Material mat) { 
-    RAYMARCH_MAP_TYPE res = raymarchCast(ro, rd);
-
-    float3 col = float3(0.0, 0.0, 0.0);
-    float3 m = res.rgb;
-    float t = res.a;
-
-    float3 pos = ro + t * rd;
-    float3 nor = raymarchNormal( pos );
-    float occ = raymarchAO( pos, nor );
-
-    mat.albedo = res;
-    mat.normal = nor;
-    mat.ambientOcclusion = occ;
-
-    #if defined(SHADING_SHADOWS)
-    float3 ref = reflect( rd, nor );
-    float3 lig = normalize( LIGHT_POSITION );
-
-    float3  hal = normalize( lig-rd );
-    float amb = saturate( 0.5+0.5*nor.y);
-    float dif = saturate( dot( nor, lig ));
-    float bac = saturate( dot( nor, normalize(float3(-lig.x,0.0,-lig.z))))*saturate( 1.0-pos.y);
-    float dom = smoothstep( -0.1, 0.1, ref.y );
-    float fre = pow( saturate(1.0+dot(nor,rd) ), 2.0 );
-
-    dif *= raymarchSoftShadow( pos, lig, 0.02, 2.5 );
-    dom *= raymarchSoftShadow( pos, ref, 0.02, 2.5 );
-
-    mat.shadows = 1.30 * dif;
-    mat.shadows += 0.40 * amb * occ;
-    mat.shadows += 0.50 * dom * occ;
-    mat.shadows += 0.50 * bac * occ;
-    mat.shadows += 0.25 * fre * occ * 0.25;
-    #endif
-}
-#endif
 
 #endif

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -44,7 +44,7 @@ license:
 float4 raymarchDefaultMaterial(Material m) {
     float3  env = RAYMARCH_AMBIENT;
 
-    float3 ref = reflect(m.V, m.normal);
+    float3 ref = reflect(-m.V, m.normal);
     float occ = raymarchAO(m.position, m.normal);
 
     #if defined(LIGHT_DIRECTION)
@@ -53,12 +53,12 @@ float4 raymarchDefaultMaterial(Material m) {
     float3 lig = normalize(LIGHT_POSITION - m.position);
     #endif
     
-    float3 hal = normalize(lig - m.V);
+    float3 hal = normalize(lig + m.V);
     float amb = saturate(0.5 + 0.5 * m.normal.y);
     float dif = saturate(dot(m.normal, lig));
     float bac = saturate(dot(m.normal, normalize(float3(-lig.x, 0.0, -lig.z)))) * saturate(1.0 - m.position.y);
     float dom = smoothstep( -0.1, 0.1, ref.y );
-    float fre = pow(saturate(1.0 + dot(m.normal, m.V)), 2.0);
+    float fre = pow(saturate(1.0 + dot(m.normal, -m.V)), 2.0);
     
     dif *= raymarchSoftShadow(m.position, lig);
     dom *= raymarchSoftShadow(m.position, ref);

--- a/lighting/raymarch/material.hlsl
+++ b/lighting/raymarch/material.hlsl
@@ -2,7 +2,6 @@
 #include "cast.hlsl"
 #include "ao.hlsl"
 #include "softShadow.hlsl"
-#include "../../math/sum.hlsl"
 
 /*
 contributors: Patricio Gonzalez Vivo
@@ -48,7 +47,7 @@ float4 raymarchDefaultMaterial(Material m) {
     float occ = raymarchAO(m.position, m.normal);
 
     #if defined(LIGHT_DIRECTION)
-    float3  lig = normalize( LIGHT_DIRECTION );
+    float3 lig = normalize(LIGHT_DIRECTION);
     #else
     float3 lig = normalize(LIGHT_POSITION - m.position);
     #endif

--- a/lighting/raymarch/normal.glsl
+++ b/lighting/raymarch/normal.glsl
@@ -8,31 +8,23 @@ examples:
     - /shaders/lighting_raymarching.frag
 */
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHNORMAL
 #define FNC_RAYMARCHNORMAL
 
 vec3 raymarchNormal(vec3 pos, vec2 pixel) {
    vec2 offset = vec2(1.0, -1.0) * pixel;
-   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).RAYMARCH_MAP_DISTANCE +
-                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).RAYMARCH_MAP_DISTANCE +
-                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).RAYMARCH_MAP_DISTANCE +
-                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).RAYMARCH_MAP_DISTANCE );
+   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).sdf +
+                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).sdf +
+                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).sdf +
+                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).sdf );
 }
 
 vec3 raymarchNormal(vec3 pos, float e) {
    vec2 offset = vec2(1.0, -1.0) * e;
-   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).RAYMARCH_MAP_DISTANCE +
-                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).RAYMARCH_MAP_DISTANCE +
-                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).RAYMARCH_MAP_DISTANCE +
-                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).RAYMARCH_MAP_DISTANCE );
+   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).sdf +
+                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).sdf +
+                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).sdf +
+                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).sdf );
 }
 
 vec3 raymarchNormal( in vec3 pos ) {

--- a/lighting/raymarch/normal.hlsl
+++ b/lighting/raymarch/normal.hlsl
@@ -19,18 +19,18 @@ use: <float> raymarchNormal( in <float3> pos )
 
 float3 raymarchNormal(float3 pos, float2 pixel) {
    float2 offset = float2(1.0, -1.0) * pixel;
-   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).RAYMARCH_MAP_DISTANCE +
-                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).RAYMARCH_MAP_DISTANCE +
-                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).RAYMARCH_MAP_DISTANCE +
-                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).RAYMARCH_MAP_DISTANCE );
+   return normalize( offset.xyy * RAYMARCH_MAP_FNC(pos + offset.xyy).sdf +
+                     offset.yyx * RAYMARCH_MAP_FNC(pos + offset.yyx).sdf +
+                     offset.yxy * RAYMARCH_MAP_FNC(pos + offset.yxy).sdf +
+                     offset.xxx * RAYMARCH_MAP_FNC(pos + offset.xxx).sdf);
 }
 
 float3 raymarchNormal(float3 pos, float e) {
    const float2 offset = float2(1.0, -1.0) * e;
-   return normalize( offset.xyy * RAYMARCH_MAP_FNC( pos + offset.xyy ).RAYMARCH_MAP_DISTANCE +
-                     offset.yyx * RAYMARCH_MAP_FNC( pos + offset.yyx ).RAYMARCH_MAP_DISTANCE +
-                     offset.yxy * RAYMARCH_MAP_FNC( pos + offset.yxy ).RAYMARCH_MAP_DISTANCE +
-                     offset.xxx * RAYMARCH_MAP_FNC( pos + offset.xxx ).RAYMARCH_MAP_DISTANCE );
+    return normalize(offset.xyy * RAYMARCH_MAP_FNC(pos + offset.xyy).sdf +
+                     offset.yyx * RAYMARCH_MAP_FNC(pos + offset.yyx).sdf +
+                     offset.yxy * RAYMARCH_MAP_FNC(pos + offset.yxy).sdf +
+                     offset.xxx * RAYMARCH_MAP_FNC(pos + offset.xxx).sdf);
 }
 
 float3 raymarchNormal( in float3 pos ) {

--- a/lighting/raymarch/normal.hlsl
+++ b/lighting/raymarch/normal.hlsl
@@ -6,14 +6,6 @@ description: Calculate normals http://iquilezles.org/www/articles/normalsSDF/nor
 use: <float> raymarchNormal( in <float3> pos ) 
 */
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHNORMAL
 #define FNC_RAYMARCHNORMAL
 

--- a/lighting/raymarch/render.glsl
+++ b/lighting/raymarch/render.glsl
@@ -4,7 +4,6 @@
 #include "softShadow.glsl"
 #include "material.glsl"
 #include "fog.glsl"
-#include "../../math/saturate.glsl"
 
 /*
 contributors:  Inigo Quiles
@@ -12,30 +11,13 @@ description: Default raymarching renderer
 use: <vec4> raymarchDefaultRender( in <vec3> rayOriging, in <vec3> rayDirection, in <vec3> cameraForward,
     out <vec3> eyeDepth, out <vec3> worldPosition, out <vec3> worldNormal ) 
 options:
-    - LIGHT_COLOR: vec3(0.5) or u_lightColor in GlslViewer
-    - LIGHT_POSITION: vec3(0.0, 10.0, -50.0) or u_light in GlslViewer
-    - LIGHT_DIRECTION;
     - RAYMARCH_BACKGROUND: vec3(0.0)
-    - RAYMARCH_AMBIENT: vec3(1.0)
-    - RAYMARCH_MATERIAL_FNC raymarchDefaultMaterial
 examples:
     - /shaders/lighting_raymarching.frag
 */
 
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_TYPE
-#define RAYMARCH_MAP_MATERIAL_TYPE vec3
-#endif
-
-#ifndef RAYMARCHCAST_TYPE
-#define RAYMARCHCAST_TYPE vec4
+#ifndef RAYMARCH_BACKGROUND
+#define RAYMARCH_BACKGROUND float3(0.0, 0.0, 0.0)
 #endif
 
 #ifndef FNC_RAYMARCHDEFAULT
@@ -45,14 +27,19 @@ vec4 raymarchDefaultRender(
     in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward,
     out float eyeDepth, out vec3 worldPos, out vec3 worldNormal ) { 
 
-    vec4 color = vec4(0.0);
-    
-    RAYMARCHCAST_TYPE res = raymarchCast(rayOrigin, rayDirection);
-    float t = res.RAYMARCH_MAP_DISTANCE;
+    Material res = raymarchCast(rayOrigin, rayDirection);
+    float t = res.sdf;
 
     worldPos = rayOrigin + t * rayDirection;
     worldNormal = raymarchNormal( worldPos );
-    color = raymarchMaterial(rayDirection, worldPos, worldNormal, res.RAYMARCH_MAP_MATERIAL);
+
+    vec4 color = vec4(RAYMARCH_BACKGROUND, 0.0);
+    if (res.valid) {
+        res.position = worldPos;
+        res.normal = worldNormal;
+        res.V = -rayDirection;
+        color = RAYMARCH_MATERIAL_FNC(res);
+    }
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
 
     // Eye-space depth. See https://www.shadertoy.com/view/4tByz3

--- a/lighting/raymarch/render.glsl
+++ b/lighting/raymarch/render.glsl
@@ -17,7 +17,7 @@ examples:
 */
 
 #ifndef RAYMARCH_BACKGROUND
-#define RAYMARCH_BACKGROUND float3(0.0, 0.0, 0.0)
+#define RAYMARCH_BACKGROUND vec3(0.0, 0.0, 0.0)
 #endif
 
 #ifndef FNC_RAYMARCHDEFAULT

--- a/lighting/raymarch/render.glsl
+++ b/lighting/raymarch/render.glsl
@@ -2,7 +2,7 @@
 #include "ao.glsl"
 #include "normal.glsl"
 #include "softShadow.glsl"
-#include "material.glsl"
+#include "shading.glsl"
 #include "fog.glsl"
 
 /*
@@ -38,7 +38,7 @@ vec4 raymarchDefaultRender(
         res.position = worldPos;
         res.normal = worldNormal;
         res.V = -rayDirection;
-        color = RAYMARCH_MATERIAL_FNC(res);
+        color = RAYMARCH_SHADING_FNC(res);
     }
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
 

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -10,30 +10,7 @@ contributors:  Inigo Quiles
 description: Default raymarching renderer
 use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
-options:
-    - LIGHT_COLOR: float3(0.5) or u_lightColor in glslViewer
-    - LIGHT_POSITION: float3(0.0, 10.0, -50.0) or u_light in GlslViewer
-    - LIGHT_DIRECTION;
-    - RAYMARCH_BACKGROUND: float3(0.0)
-    - RAYMARCH_AMBIENT: float3(1.0)
-    - RAYMARCH_MATERIAL_FNC raymarchDefaultMaterial
 */
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL
-#define RAYMARCH_MAP_MATERIAL rgb
-#endif
-
-#ifndef RAYMARCH_MAP_MATERIAL_TYPE
-#define RAYMARCH_MAP_MATERIAL_TYPE float3
-#endif
-
-#ifndef RAYMARCHCAST_TYPE
-#define RAYMARCHCAST_TYPE float4
-#endif
 
 #ifndef FNC_RAYMARCHDEFAULT
 #define FNC_RAYMARCHDEFAULT
@@ -44,12 +21,12 @@ float4 raymarchDefaultRender(
 
     float4 color = float4(0.0, 0.0, 0.0, 0.0);
     
-    RAYMARCHCAST_TYPE res = raymarchCast(rayOrigin, rayDirection);
-    float t = res.RAYMARCH_MAP_DISTANCE;
+    Material res = raymarchCast(rayOrigin, rayDirection);
+    float t = res.sdf;
 
     worldPos = rayOrigin + t * rayDirection;
     worldNormal = raymarchNormal( worldPos );
-    color = raymarchMaterial(rayDirection, worldPos, worldNormal, res.RAYMARCH_MAP_MATERIAL);
+    color = RAYMARCH_MATERIAL_FNC(rayDirection, worldPos, worldNormal, res).albedo;
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
 
     // Eye-space depth. See https://www.shadertoy.com/view/4tByz3

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -12,6 +12,10 @@ use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirect
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 */
 
+#ifndef RAYMARCH_BACKGROUND
+#define RAYMARCH_BACKGROUND float3(0.0, 0.0, 0.0)
+#endif
+
 #ifndef FNC_RAYMARCHDEFAULT
 #define FNC_RAYMARCHDEFAULT
 
@@ -19,14 +23,20 @@ float4 raymarchDefaultRender(
     in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
     out float eyeDepth, out float3 worldPos, out float3 worldNormal ) { 
 
-    float4 color = float4(0.0, 0.0, 0.0, 0.0);
     
     Material res = raymarchCast(rayOrigin, rayDirection);
     float t = res.sdf;
 
     worldPos = rayOrigin + t * rayDirection;
     worldNormal = raymarchNormal( worldPos );
-    color = RAYMARCH_MATERIAL_FNC(rayDirection, worldPos, worldNormal, res).albedo;
+
+    float4 color = float4(RAYMARCH_BACKGROUND, 0.0);
+    if (res.valid) {
+        res.position = worldPos;
+        res.normal = worldNormal;
+        res.V = rayDirection;
+        color = RAYMARCH_MATERIAL_FNC(res);
+    }
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
 
     // Eye-space depth. See https://www.shadertoy.com/view/4tByz3

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -2,7 +2,7 @@
 #include "ao.hlsl"
 #include "normal.hlsl"
 #include "softShadow.hlsl"
-#include "material.hlsl"
+#include "shading.hlsl"
 #include "fog.hlsl"
 
 /*
@@ -36,7 +36,7 @@ float4 raymarchDefaultRender(
         res.position = worldPos;
         res.normal = worldNormal;
         res.V = -rayDirection;
-        color = RAYMARCH_MATERIAL_FNC(res);
+        color = RAYMARCH_SHADING_FNC(res);
     }
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);
 

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -34,7 +34,7 @@ float4 raymarchDefaultRender(
     if (res.valid) {
         res.position = worldPos;
         res.normal = worldNormal;
-        res.V = rayDirection;
+        res.V = -rayDirection;
         color = RAYMARCH_MATERIAL_FNC(res);
     }
     color.rgb = raymarchFog(color.rgb, t, rayOrigin, rayDirection);

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -10,6 +10,8 @@ contributors:  Inigo Quiles
 description: Default raymarching renderer
 use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
+options:
+    - RAYMARCH_BACKGROUND: vec3(0.0)
 */
 
 #ifndef RAYMARCH_BACKGROUND
@@ -23,7 +25,6 @@ float4 raymarchDefaultRender(
     in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
     out float eyeDepth, out float3 worldPos, out float3 worldNormal ) { 
 
-    
     Material res = raymarchCast(rayOrigin, rayDirection);
     float t = res.sdf;
 

--- a/lighting/raymarch/shading.glsl
+++ b/lighting/raymarch/shading.glsl
@@ -1,75 +1,78 @@
-#include "normal.hlsl"
-#include "cast.hlsl"
-#include "ao.hlsl"
-#include "softShadow.hlsl"
+#include "normal.glsl"
+#include "cast.glsl"
+#include "ao.glsl"
+#include "softShadow.glsl"
+#include "../../math/saturate.glsl"
 
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
     Material Constructor. Designed to integrate with GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
 use:
-    - void raymarchMaterial(in <float3> ro, in <float3> rd, out material _mat)
-    - material raymarchMaterial(in <float3> ro, in <float3> rd)
+    - void raymarchMaterial(in <vec3> ro, in <vec3> rd, out material _mat)
+    - material raymarchMaterial(in <vec3> ro, in <vec3> rd)
 options:
     - LIGHT_POSITION: in glslViewer is u_light
     - LIGHT_DIRECTION
     - LIGHT_COLOR
     - RAYMARCH_AMBIENT
-    - RAYMARCH_MATERIAL_FNC(RAY, POSITION, NORMAL, ALBEDO)
+    - RAYMARCH_SHADING_FNC(RAY, POSITION, NORMAL, ALBEDO)
+examples:
+    - /shaders/lighting_raymarching.frag
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
 #ifndef LIGHT_POSITION
-#define LIGHT_POSITION float3(0.0, 10.0, -50.0)
+#define LIGHT_POSITION vec3(0.0, 10.0, -50.0)
 #endif
 
 #ifndef LIGHT_COLOR
-#define LIGHT_COLOR float3(1.0, 1.0, 1.0)
+#define LIGHT_COLOR vec3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
+#define RAYMARCH_AMBIENT vec3(1.0, 1.0, 1.0)
 #endif
 
-#ifndef RAYMARCH_MATERIAL_FNC
-#define RAYMARCH_MATERIAL_FNC raymarchDefaultMaterial
+#ifndef RAYMARCH_SHADING_FNC
+#define RAYMARCH_SHADING_FNC raymarchDefaultShading
 #endif
 
-#ifndef FNC_RAYMARCHMATERIAL
-#define FNC_RAYMARCHMATERIAL
+#ifndef FNC_RAYMARCHDEFAULTSHADING
+#define FNC_RAYMARCHDEFAULTSHADING
 
-float4 raymarchDefaultMaterial(Material m) {
-    float3  env = RAYMARCH_AMBIENT;
+vec4 raymarchDefaultShading(Material m) {
+    vec3  env = RAYMARCH_AMBIENT;
 
-    float3 ref = reflect(-m.V, m.normal);
+    vec3 ref = reflect(-m.V, m.normal);
     float occ = raymarchAO(m.position, m.normal);
 
     #if defined(LIGHT_DIRECTION)
-    float3 lig = normalize(LIGHT_DIRECTION);
+    vec3 lig = normalize( LIGHT_DIRECTION );
     #else
-    float3 lig = normalize(LIGHT_POSITION - m.position);
+    vec3 lig = normalize(LIGHT_POSITION - m.position);
     #endif
     
-    float3 hal = normalize(lig + m.V);
+    vec3 hal = normalize(lig + m.V);
     float amb = saturate(0.5 + 0.5 * m.normal.y);
     float dif = saturate(dot(m.normal, lig));
-    float bac = saturate(dot(m.normal, normalize(float3(-lig.x, 0.0, -lig.z)))) * saturate(1.0 - m.position.y);
+    float bac = saturate(dot(m.normal, normalize(vec3(-lig.x, 0.0, -lig.z)))) * saturate(1.0 - m.position.y);
     float dom = smoothstep( -0.1, 0.1, ref.y );
     float fre = pow(saturate(1.0 + dot(m.normal, -m.V)), 2.0);
     
     dif *= raymarchSoftShadow(m.position, lig);
     dom *= raymarchSoftShadow(m.position, ref);
 
-    float3 light = float3(0.0, 0.0, 0.0);
+    vec3 light = vec3(0.0, 0.0, 0.0);
     light += 1.30 * dif * LIGHT_COLOR;
     light += 0.40 * amb * occ * env;
     light += 0.50 * dom * occ * env;
     light += 0.50 * bac * occ * 0.25;
     light += 0.25 * fre * occ;
 
-    return float4(m.albedo.rgb * light, m.albedo.a);
+    return vec4(m.albedo.rgb * light, m.albedo.a);
 }
 
 #endif

--- a/lighting/raymarch/shading.hlsl
+++ b/lighting/raymarch/shading.hlsl
@@ -1,78 +1,75 @@
-#include "normal.glsl"
-#include "cast.glsl"
-#include "ao.glsl"
-#include "softShadow.glsl"
-#include "../../math/saturate.glsl"
+#include "normal.hlsl"
+#include "cast.hlsl"
+#include "ao.hlsl"
+#include "softShadow.hlsl"
 
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
     Material Constructor. Designed to integrate with GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
 use:
-    - void raymarchMaterial(in <vec3> ro, in <vec3> rd, out material _mat)
-    - material raymarchMaterial(in <vec3> ro, in <vec3> rd)
+    - void raymarchMaterial(in <float3> ro, in <float3> rd, out material _mat)
+    - material raymarchMaterial(in <float3> ro, in <float3> rd)
 options:
     - LIGHT_POSITION: in glslViewer is u_light
     - LIGHT_DIRECTION
     - LIGHT_COLOR
     - RAYMARCH_AMBIENT
-    - RAYMARCH_MATERIAL_FNC(RAY, POSITION, NORMAL, ALBEDO)
-examples:
-    - /shaders/lighting_raymarching.frag
+    - RAYMARCH_SHADING_FNC(RAY, POSITION, NORMAL, ALBEDO)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
 #ifndef LIGHT_POSITION
-#define LIGHT_POSITION vec3(0.0, 10.0, -50.0)
+#define LIGHT_POSITION float3(0.0, 10.0, -50.0)
 #endif
 
 #ifndef LIGHT_COLOR
-#define LIGHT_COLOR vec3(1.0, 1.0, 1.0)
+#define LIGHT_COLOR float3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT vec3(1.0, 1.0, 1.0)
+#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
 #endif
 
-#ifndef RAYMARCH_MATERIAL_FNC
-#define RAYMARCH_MATERIAL_FNC raymarchDefaultMaterial
+#ifndef RAYMARCH_SHADING_FNC
+#define RAYMARCH_SHADING_FNC raymarchDefaultShading
 #endif
 
-#ifndef FNC_RAYMARCHMATERIAL
-#define FNC_RAYMARCHMATERIAL
+#ifndef FNC_RAYMARCHDEFAULTSHADING
+#define FNC_RAYMARCHDEFAULTSHADING
 
-vec4 raymarchDefaultMaterial(Material m) {
-    vec3  env = RAYMARCH_AMBIENT;
+float4 raymarchDefaultShading(Material m) {
+    float3  env = RAYMARCH_AMBIENT;
 
-    vec3 ref = reflect(-m.V, m.normal);
+    float3 ref = reflect(-m.V, m.normal);
     float occ = raymarchAO(m.position, m.normal);
 
     #if defined(LIGHT_DIRECTION)
-    vec3 lig = normalize( LIGHT_DIRECTION );
+    float3 lig = normalize(LIGHT_DIRECTION);
     #else
-    vec3 lig = normalize(LIGHT_POSITION - m.position);
+    float3 lig = normalize(LIGHT_POSITION - m.position);
     #endif
     
-    vec3 hal = normalize(lig + m.V);
+    float3 hal = normalize(lig + m.V);
     float amb = saturate(0.5 + 0.5 * m.normal.y);
     float dif = saturate(dot(m.normal, lig));
-    float bac = saturate(dot(m.normal, normalize(vec3(-lig.x, 0.0, -lig.z)))) * saturate(1.0 - m.position.y);
+    float bac = saturate(dot(m.normal, normalize(float3(-lig.x, 0.0, -lig.z)))) * saturate(1.0 - m.position.y);
     float dom = smoothstep( -0.1, 0.1, ref.y );
     float fre = pow(saturate(1.0 + dot(m.normal, -m.V)), 2.0);
     
     dif *= raymarchSoftShadow(m.position, lig);
     dom *= raymarchSoftShadow(m.position, ref);
 
-    vec3 light = vec3(0.0, 0.0, 0.0);
+    float3 light = float3(0.0, 0.0, 0.0);
     light += 1.30 * dif * LIGHT_COLOR;
     light += 0.40 * amb * occ * env;
     light += 0.50 * dom * occ * env;
     light += 0.50 * bac * occ * 0.25;
     light += 0.25 * fre * occ;
 
-    return vec4(m.albedo.rgb * light, m.albedo.a);
+    return float4(m.albedo.rgb * light, m.albedo.a);
 }
 
 #endif

--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -30,14 +30,6 @@ examples:
 #define RAYMARCH_SHADOW_SOLID_ANGLE 0.1
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHSOFTSHADOW
 #define FNC_RAYMARCHSOFTSHADOW
 
@@ -46,7 +38,7 @@ float raymarchSoftShadow(vec3 ro, vec3 rd, in float mint, in float maxt, float w
     float t = mint;
     for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++)
     {
-        float h = RAYMARCH_MAP_FNC(ro + t * rd).RAYMARCH_MAP_DISTANCE;
+        float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
         t += clamp(h, 0.005, 0.50);
         if (res < -1.0 || t > maxt)

--- a/lighting/raymarch/softShadow.hlsl
+++ b/lighting/raymarch/softShadow.hlsl
@@ -27,14 +27,6 @@ options:
 #define RAYMARCH_SHADOW_SOLID_ANGLE 0.1
 #endif
 
-#ifndef RAYMARCH_MAP_FNC
-#define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
-#endif
-
-#ifndef RAYMARCH_MAP_DISTANCE
-#define RAYMARCH_MAP_DISTANCE a
-#endif
-
 #ifndef FNC_RAYMARCHSOFTSHADOW
 #define FNC_RAYMARCHSOFTSHADOW
 
@@ -43,7 +35,7 @@ float raymarchSoftShadow( float3 ro, float3 rd, in float mint, in float maxt, fl
     float t = mint;
     for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++)
     {
-        float h = RAYMARCH_MAP_FNC(ro + t * rd).RAYMARCH_MAP_DISTANCE;
+        float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
         t += clamp(h, 0.005, 0.50);
         if (res < -1.0 || t > maxt)

--- a/lighting/raymarch/volume.glsl
+++ b/lighting/raymarch/volume.glsl
@@ -81,13 +81,13 @@ vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward
             #ifdef LIGHT_POSITION
             float Tl = 1.0;
             for (int j = 0; j < nbSampleLight; j++) {
-                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).a;
+                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).sdf;
                 if (densityLight>0.)
                     Tl *= 1. - densityLight * absorption/fSamples;
                 if (Tl <= 0.01)
                     break;
             }
-            col += LIGHT_COLOR * 80. * tmp * T * Tl;
+            col += vec4(LIGHT_COLOR * 80. * tmp * T * Tl, 1.0);
             #endif
         }
         pos += rayDirection * tstep;

--- a/lighting/raymarch/volume.glsl
+++ b/lighting/raymarch/volume.glsl
@@ -1,9 +1,8 @@
-#include "../../math/saturate.glsl"
-
 /*
 contributors:  Inigo Quiles
 description: Default raymarching renderer
-use: <vec4> raymarchDefaultRender( in <vec3> rayOrigin, in <vec3> rd ) 
+use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
+    out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
     - RAYMARCH_MATERIAL_FNC(RGB) vec3(RGB)
     - RAYMARCH_BACKGROUND vec3(0.0)
@@ -20,10 +19,6 @@ examples:
 #else
 #define LIGHT_COLOR vec3(0.5)
 #endif
-#endif
-
-#ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT vec3(1.0)
 #endif
 
 #ifndef RAYMARCH_BACKGROUND
@@ -54,7 +49,7 @@ examples:
 #define FNC_RAYMARCHVOLUMERENDER
 
 vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward,
-                    out float eyeDepth, out vec3 worldPos, out vec3 worldNormal) {
+                     out float eyeDepth, out vec3 worldPos, out vec3 worldNormal) {
 
     const float tmin        = RAYMARCH_MIN_DIST;
     const float tmax        = RAYMARCH_MAX_DIST;
@@ -104,7 +99,7 @@ vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward
     worldNormal = raymarchNormal( worldPos );
     eyeDepth = t * dot(rayDirection, cameraForward);
 
-    return vec4(saturate(col), t);
+    return vec4(col, t);
 }
 
 #endif

--- a/lighting/raymarch/volume.glsl
+++ b/lighting/raymarch/volume.glsl
@@ -7,7 +7,6 @@ description: Default raymarching renderer
 use: <vec4> raymarchVolume( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
-    - RAYMARCH_MATERIAL_FNC(RGB) vec3(RGB)
     - RAYMARCH_BACKGROUND vec3(0.0)
     - RAYMARCH_AMBIENT vec3(1.0)
     - LIGHT_COLOR     vec3(0.5)

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -1,7 +1,10 @@
+#include "map.hlsl"
+#include "normal.hlsl"
+
 /*
 contributors:  Inigo Quiles
 description: Default raymarching renderer
-use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
+use: <vec4> raymarchVolume( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
     - RAYMARCH_MATERIAL_FNC(RGB) float3(RGB)
@@ -34,10 +37,6 @@ options:
 #define RAYMARCH_MAX_DIST 10.0
 #endif
 
-#ifndef RAYMARCH_VOLUME_COLOR_FNC
-#define RAYMARCH_VOLUME_COLOR_FNC float3
-#endif
-
 #ifndef RAYMARCH_MAP_FNC
 #define RAYMARCH_MAP_FNC(POS) raymarchMap(POS)
 #endif
@@ -45,8 +44,9 @@ options:
 #ifndef FNC_RAYMARCHVOLUMERENDER
 #define FNC_RAYMARCHVOLUMERENDER
 
-vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward,
-                     out float eyeDepth, out vec3 worldPos, out vec3 worldNormal) {
+float4 raymarchVolume(in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
+                      out float eyeDepth, out float3 worldPos, out float3 worldNormal)
+{
 
     const float tmin        = RAYMARCH_MIN_DIST;
     const float tmax        = RAYMARCH_MAX_DIST;
@@ -63,18 +63,18 @@ vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward
 
     float T = 1.;
     float t = tmin;
-    float3 col = float3(0.0, 0.0, 0.0);
+    float4 col = float4(0.0, 0.0, 0.0, 0.0);
     float3 pos = rayOrigin;
     for(int i = 0; i < RAYMARCH_SAMPLES; i++) {
-        float4 res    = RAYMARCH_MAP_FNC(pos);
-        float density = (0.1 - res.a);
+        Material res    = RAYMARCH_MAP_FNC(pos);
+        float density = (0.1 - res.sdf);
         if (density > 0.0) {
             float tmp = density / fSamples;
             T *= 1.0 - tmp * absorption;
             if( T <= 0.001)
                 break;
 
-            col += RAYMARCH_VOLUME_COLOR_FNC(res.rgb) * fSamples * tmp * T;
+            col += res.albedo * fSamples * tmp * T;
                 
             //Light scattering
             #ifdef LIGHT_POSITION
@@ -96,7 +96,7 @@ vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward
     worldNormal = raymarchNormal( worldPos );
     eyeDepth = t * dot(rayDirection, cameraForward);
 
-    return float4(col, t);
+    return col;
 }
 
 #endif

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -79,13 +79,13 @@ float4 raymarchVolume(in float3 rayOrigin, in float3 rayDirection, float3 camera
             #ifdef LIGHT_POSITION
             float Tl = 1.0;
             for (int j = 0; j < nbSampleLight; j++) {
-                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).a;
+                float densityLight = RAYMARCH_MAP_FNC( pos + sun_direction * float(j) * tstepl ).sdf;
                 if (densityLight>0.)
                     Tl *= 1. - densityLight * absorption/fSamples;
                 if (Tl <= 0.01)
                     break;
             }
-            col += LIGHT_COLOR * 80. * tmp * T * Tl;
+            col += float4(LIGHT_COLOR * 80. * tmp * T * Tl, 1.0);
             #endif
         }
         pos += rayDirection * tstep;

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -1,11 +1,11 @@
 /*
 contributors:  Inigo Quiles
 description: Default raymarching renderer
-use: <float4> raymarchDefaultRender( in  float3> ro, in  float3> rd ) 
+use: <vec4> raymarchDefaultRender( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
+    out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
     - RAYMARCH_MATERIAL_FNC(RGB) float3(RGB)
     - RAYMARCH_BACKGROUND float3(0.0)
-    - RAYMARCH_AMBIENT float3(1.0)
     - LIGHT_COLOR     float3(0.5)
     - LIGHT_POSITION  float3(0.0, 10.0, -50.0)
 */
@@ -16,10 +16,6 @@ options:
 #else
 #define LIGHT_COLOR float3(0.5, 0.5, 0.5)
 #endif
-#endif
-
-#ifndef RAYMARCH_AMBIENT
-#define RAYMARCH_AMBIENT float3(1.0, 1.0, 1.0)
 #endif
 
 #ifndef RAYMARCH_BACKGROUND
@@ -49,7 +45,8 @@ options:
 #ifndef FNC_RAYMARCHVOLUMERENDER
 #define FNC_RAYMARCHVOLUMERENDER
 
-float4 raymarchVolume( in float3 ro, in float3 rd ) {
+vec4 raymarchVolume( in vec3 rayOrigin, in vec3 rayDirection, vec3 cameraForward,
+                     out float eyeDepth, out vec3 worldPos, out vec3 worldNormal) {
 
     const float tmin        = RAYMARCH_MIN_DIST;
     const float tmax        = RAYMARCH_MAX_DIST;
@@ -67,7 +64,7 @@ float4 raymarchVolume( in float3 ro, in float3 rd ) {
     float T = 1.;
     float t = tmin;
     float3 col = float3(0.0, 0.0, 0.0);
-    float3 pos = ro;
+    float3 pos = rayOrigin;
     for(int i = 0; i < RAYMARCH_SAMPLES; i++) {
         float4 res    = RAYMARCH_MAP_FNC(pos);
         float density = (0.1 - res.a);
@@ -92,10 +89,14 @@ float4 raymarchVolume( in float3 ro, in float3 rd ) {
             col += LIGHT_COLOR * 80. * tmp * T * Tl;
             #endif
         }
-        pos += rd * tstep;
+        pos += rayDirection * tstep;
     }
 
-    return float4(saturate(col), t);
+    worldPos = rayOrigin + t * rayDirection;
+    worldNormal = raymarchNormal( worldPos );
+    eyeDepth = t * dot(rayDirection, cameraForward);
+
+    return float4(col, t);
 }
 
 #endif

--- a/lighting/raymarch/volume.hlsl
+++ b/lighting/raymarch/volume.hlsl
@@ -7,7 +7,6 @@ description: Default raymarching renderer
 use: <vec4> raymarchVolume( in <float3> rayOriging, in <float3> rayDirection, in <float3> cameraForward,
     out <float3> eyeDepth, out <float3> worldPosition, out <float3> worldNormal ) 
 options:
-    - RAYMARCH_MATERIAL_FNC(RGB) float3(RGB)
     - RAYMARCH_BACKGROUND float3(0.0)
     - LIGHT_COLOR     float3(0.5)
     - LIGHT_POSITION  float3(0.0, 10.0, -50.0)

--- a/sdf/opIntersection.glsl
+++ b/sdf/opIntersection.glsl
@@ -1,4 +1,5 @@
 #include "../math/saturate.glsl"
+#include "../lighting/material.glsl"
 
 /*
 contributors:  Inigo Quiles

--- a/sdf/opIntersection.glsl
+++ b/sdf/opIntersection.glsl
@@ -11,6 +11,15 @@ use: <float> opIntersection( in <float> d1, in <float> d2 [, <float> smooth_fact
 
 float opIntersection( float d1, float d2 ) { return max(d1,d2); }
 
+Material opIntersection(Material d1, Material d2)
+{
+    if (d1.sdf > d2.sdf){
+        return d1;
+    } else {
+        return d2;
+    }
+}
+
 float opIntersection( float d1, float d2, float k ) {
     float h = saturate( 0.5 - 0.5*(d2-d1)/k );
     return mix( d2, d1, h ) + k*h*(1.0-h); 

--- a/sdf/opIntersection.hlsl
+++ b/sdf/opIntersection.hlsl
@@ -1,4 +1,4 @@
-#include "../lighting/material/new.hlsl"
+#include "../lighting/material.hlsl"
 
 /*
 contributors:  Inigo Quiles

--- a/sdf/opIntersection.hlsl
+++ b/sdf/opIntersection.hlsl
@@ -1,3 +1,5 @@
+#include "../lighting/material/new.hlsl"
+
 /*
 contributors:  Inigo Quiles
 description: intersection operation of two SDFs 
@@ -8,6 +10,15 @@ use: <float> opIntersection( in <float> d1, in <float> d2 [, <float> smooth_fact
 #define FNC_OPINTERSECTION
 
 float opIntersection( float d1, float d2 ) { return max(d1,d2); }
+
+Material opIntersection(Material d1, Material d2)
+{
+    if (d1.sdf > d2.sdf){
+        return d1;
+    } else {
+        return d2;
+    }
+}
 
 float opIntersection( float d1, float d2, float k ) {
     float h = saturate( 0.5 - 0.5*(d2-d1)/k );

--- a/sdf/opUnion.glsl
+++ b/sdf/opUnion.glsl
@@ -10,7 +10,14 @@ use: <float> opUnion( in <float|vec4> d1, in <float|vec4> d2 [, <float> smooth_f
 #define FNC_OPUNION
 
 float opUnion( float d1, float d2 ) { return min(d1, d2); }
-vec4  opUnion( vec4 d1, vec4 d2 ) { return (d1.a < d2.a) ? d1 : d2; }
+
+Material opUnion( Material d1, Material d2 ) {
+    if (d1.sdf < d2.sdf) {
+        return d1;
+    } else {
+        return d2;
+    }
+}
 
 // Soft union
 float opUnion( float d1, float d2, float k ) {

--- a/sdf/opUnion.glsl
+++ b/sdf/opUnion.glsl
@@ -1,4 +1,5 @@
 #include "../math/saturate.glsl"
+#include "../lighting/material.glsl"
 
 /*
 contributors:  Inigo Quiles

--- a/sdf/opUnion.hlsl
+++ b/sdf/opUnion.hlsl
@@ -1,4 +1,4 @@
-#include "../lighting/material/new.hlsl"
+#include "../lighting/material.hlsl"
 
 /*
 contributors:  Inigo Quiles

--- a/sdf/opUnion.hlsl
+++ b/sdf/opUnion.hlsl
@@ -1,3 +1,5 @@
+#include "../lighting/material/new.hlsl"
+
 /*
 contributors:  Inigo Quiles
 description: Union operation of two SDFs 
@@ -8,7 +10,14 @@ use: <float> opUnion( in <float|float4> d1, in <float|float4> d2 [, <float> smoo
 #define FNC_OPUNION
 
 float opUnion( float d1, float d2 ) { return min(d1, d2); }
-float4  opUnion( float4 d1, float4 d2 ) { return (d1.a < d2.a) ? d1 : d2; }
+
+Material opUnion( Material d1, Material d2 ) {
+    if (d1.sdf < d2.sdf) {
+        return d1;
+    } else {
+        return d2;
+    }
+}
 
 // Soft union
 float opUnion( float d1, float d2, float k ) {


### PR DESCRIPTION
This is part of a pretty thorough overhaul of the raymarching material framework. Client-side modifications are required, but we tried to keep them manageable.

The objectives are:
* Make the system more flexible and amenable to evolution
* Allow multiple materials per scene
* Integrate with Lygia mesh-based shading pipelines, starting with PBR

The previous material system relies on a single `vec4` which encodes colour and distance (from SDF).
* Material properties are not supported on the fragment level. eg. everything in the scene is metallic or not.
* No out-of-the-box integration with existing models

We replace this `vec4` with the existing `Material` struct.
* Every single fragment now specifies its own material properties. We can mix and match metallic/dielectric smooth/rough objects, at the fragment level.
* Tightly integrated with existing shading algorithm. Switching from the default raymarching shading model to the super-sexy Lygia PBR model is as easy as adding: `#define RAYMARCH_SHADING_FNC pbr`

Example raymarching map function (default shader):

![Screenshot 2024-08-01 134834](https://github.com/user-attachments/assets/fc42e18b-8b85-4d78-ad9e-0908f37ab162)

```glsl
Material raymarchMap( in vec3 pos ) {
    Material res = materialNew();
    res.sdf = RAYMARCH_MAX_DIST;

    float check = checkBoard(pos.xz, vec2(1.0, 1.0));

    res = opUnion( res, materialNew(0.5 + vec3(check, check, check) * 0.5, 0.0, 0.5, planeSDF(pos)));

    res = opUnion( res, materialNew( vec3(1.0, 1.0, 1.0), sphereSDF(   pos-vec3( 0.0, 0.60, 0.0), 0.5 ) ) );
    res = opUnion( res, materialNew( vec3(0.0, 1.0, 1.0), boxSDF(      pos-vec3( 2.0, 0.5, 0.0), vec3(0.4, 0.4, 0.4) ) ) );
    res = opUnion( res, materialNew( vec3(0.3, 0.3, 1.0), torusSDF(    pos-vec3( 0.0, 0.5, 2.0), vec2(0.4,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.3, 0.1, 0.3), capsuleSDF(  pos,vec3(-2.3, 0.4,-0.2), vec3(-1.6,0.75,0.2), 0.2 ) ) );
    res = opUnion( res, materialNew( vec3(0.5, 0.3, 0.4), triPrismSDF( pos-vec3(-2.0, 0.50,-2.0), vec2(0.5,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.2, 0.2, 0.8), cylinderSDF( pos-vec3( 2.0, 0.50,-2.0), vec2(0.2,0.4) ) ) );
    res = opUnion( res, materialNew( vec3(0.7, 0.5, 0.2), coneSDF(     pos-vec3( 0.0, 0.75,-2.0), vec3(0.8,0.6,0.6) ) ) );
    res = opUnion( res, materialNew( vec3(0.4, 0.2, 0.9), hexPrismSDF( pos-vec3(-2.0, 0.60, 2.0), vec2(0.5,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.1, 0.3, 0.6), pyramidSDF(  pos-vec3( 2.0, 0.10, 2.0), 1.0 ) ) );;

    return res;
}
``` 
Example raymarching map function (multiple PBR materials):

![Screenshot 2024-08-01 145856](https://github.com/user-attachments/assets/100f287e-0868-4fd5-bfe5-41f85d871719)

```glsl

#define RAYMARCH_SHADING_FNC pbr

Material raymarchMap( in vec3 pos ) {
    Material res = materialNew();
    res.sdf = RAYMARCH_MAX_DIST;

    float check = checkBoard(pos.xz, vec2(1.0, 1.0));

    res = opUnion( res, materialNew(0.5 + vec3(check, check, check) * 0.5, 0.0, 0.5, planeSDF(pos)));

    res = opUnion( res, materialNew( vec3(1.0, 1.0, 1.0), 1.0, 0.0, sphereSDF(   pos-vec3( 0.0, 0.60, 0.0), 0.5 ) ) );
    res = opUnion( res, materialNew( vec3(0.0, 1.0, 1.0), 1.0, 0.2, boxSDF(      pos-vec3( 2.0, 0.5, 0.0), vec3(0.4, 0.4, 0.4) ) ) );
    res = opUnion( res, materialNew( vec3(0.3, 0.3, 1.0), 1.0, 0.0, torusSDF(    pos-vec3( 0.0, 0.5, 2.0), vec2(0.4,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.3, 0.1, 0.3), 1.0, 0.0, capsuleSDF(  pos,vec3(-2.3, 0.4,-0.2), vec3(-1.6,0.75,0.2), 0.2 ) ) );
    res = opUnion( res, materialNew( vec3(0.5, 0.3, 0.4), 0.0, 0.0, triPrismSDF( pos-vec3(-2.0, 0.50,-2.0), vec2(0.5,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.2, 0.2, 0.8), 0.0, 0.0, cylinderSDF( pos-vec3( 2.0, 0.50,-2.0), vec2(0.2,0.4) ) ) );
    res = opUnion( res, materialNew( vec3(0.7, 0.5, 0.2), 1.0, 0.1, coneSDF(     pos-vec3( 0.0, 0.75,-2.0), vec3(0.8,0.6,0.6) ) ) );
    res = opUnion( res, materialNew( vec3(0.4, 0.2, 0.9), 0.0, 1.0, hexPrismSDF( pos-vec3(-2.0, 0.60, 2.0), vec2(0.5,0.1) ) ) );
    res = opUnion( res, materialNew( vec3(0.1, 0.3, 0.6), 0.0, 1.0, pyramidSDF(  pos-vec3( 2.0, 0.10, 2.0), 1.0 ) ) );;

    return res;
}
```

Notice how materials are specified using the material constructor shortcut `Material materialNew(vec3 albedo, float metallic, float roughness, float sdf)`

Future work
* Integrate with the raymarching volume renderer and allow mixing volume and solid in the same scene.