### PR TITLE
Fixed and optimised rotate functions.

### DIFF
--- a/math/rotate2d.glsl
+++ b/math/rotate2d.glsl
@@ -12,6 +12,6 @@ license:
 mat2 rotate2d(const in float r){
     float c = cos(r);
     float s = sin(r);
-    return mat2(c, -s, s, c);
+    return mat2(c, s, -s, c);
 }
 #endif

--- a/math/rotate2d.hlsl
+++ b/math/rotate2d.hlsl
@@ -9,9 +9,9 @@ license:
 
 #ifndef FNC_ROTATE2D
 #define FNC_ROTATE2D
-float2x2 rotate2d(const in float radians){
-    float c = cos(radians);
-    float s = sin(radians);
+float2x2 rotate2d(const in float r){
+    float c = cos(r);
+    float s = sin(r);
     return float2x2(c, -s, s, c);
 }
 #endif

--- a/math/rotate3d.glsl
+++ b/math/rotate3d.glsl
@@ -14,8 +14,9 @@ mat3 rotate3d(in vec3 a, const in float r) {
     float s = sin(r);
     float c = cos(r);
     float oc = 1.0 - c;
-    return mat3(oc * a.x * a.x + c,           oc * a.x * a.y - a.z * s,  oc * a.z * a.x + a.y * s,
-                oc * a.x * a.y + a.z * s,  oc * a.y * a.y + c,           oc * a.y * a.z - a.x * s,
-                oc * a.z * a.x - a.y * s,  oc * a.y * a.z + a.x * s,  oc * a.z * a.z + c );
+    vec3 col1 = vec3(oc * a.x * a.x + c, oc * a.x * a.y + a.z * s, oc * a.z * a.x - a.y * s);
+    vec3 col2 = vec3(oc * a.x * a.y - a.z * s, oc * a.y * a.y + c, oc * a.y * a.z + a.x * s);
+    vec3 col3 = vec3(oc * a.z * a.x + a.y * s, oc * a.y * a.z - a.x * s, oc * a.z * a.z + c);
+    return mat3(col1, col2, col3);
 }
 #endif

--- a/math/rotate3dX.glsl
+++ b/math/rotate3dX.glsl
@@ -10,8 +10,10 @@ license:
 #ifndef FNC_ROTATE3DX
 #define FNC_ROTATE3DX
 mat3 rotate3dX(const in float r){
+    float c = cos(r);
+    float s = sin(r);
     return mat3(vec3(1.0,0.0,0.0),
-                vec3(0.0,cos(r),-sin(r)),
-                vec3(0.0,sin(r),cos(r)));
+                vec3(0.0,c,s),
+                vec3(0.0,-s,c));
 }
 #endif

--- a/math/rotate3dX.hlsl
+++ b/math/rotate3dX.hlsl
@@ -10,8 +10,10 @@ license:
 #ifndef FNC_ROTATE3DX
 #define FNC_ROTATE3DX
 float3x3 rotate3dX(const in float r){
+    float c = cos(r);
+    float s = sin(r);
     return float3x3(float3(1.0,0.0,0.0),
-                    float3(0.0,cos(r),-sin(r)),
-                    float3(0.0,sin(r),cos(r)));
+                    float3(0.0,c,-s),
+                    float3(0.0,s,c));
 }
 #endif

--- a/math/rotate3dY.glsl
+++ b/math/rotate3dY.glsl
@@ -9,9 +9,11 @@ license:
 
 #ifndef FNC_ROTATE3DY
 #define FNC_ROTATE3DY
-mat3 rotate3dY(const in float theta){
-    return mat3(vec3(cos(theta),0.,-sin(theta)),
+mat3 rotate3dY(const in float r){
+    float c = cos(r);
+    float s = sin(r);
+    return mat3(vec3(c,0.,-s),
                 vec3(0.,1.,0.),
-                vec3(sin(theta),0.,cos(theta)));
+                vec3(s,0.,c));
 }
 #endif

--- a/math/rotate3dY.hlsl
+++ b/math/rotate3dY.hlsl
@@ -9,9 +9,11 @@ license:
 
 #ifndef FNC_ROTATE3DY
 #define FNC_ROTATE3DY
-float3x3 rotate3dY(const in float theta){
-    return float3x3(float3(cos(theta),0.,-sin(theta)),
+float3x3 rotate3dY(const in float r){
+    float c = cos(r);
+    float s = sin(r);
+    return float3x3(float3(c,0.,s),
                     float3(0.,1.,0.),
-                    float3(sin(theta),0.,cos(theta)));
+                    float3(-s,0.,c));
 }
 #endif

--- a/math/rotate3dZ.glsl
+++ b/math/rotate3dZ.glsl
@@ -10,8 +10,10 @@ license:
 #ifndef FNC_ROTATE3DZ
 #define FNC_ROTATE3DZ
 mat3 rotate3dZ(const in float r){
-    return mat3(vec3(cos(r),-sin(r),0.),
-                vec3(sin(r),cos(r),0.),
+    float c = cos(r);
+    float s = sin(r);
+    return mat3(vec3(c,s,0.),
+                vec3(-s,c,0.),
                 vec3(0.,0.,1.));
 }
 #endif

--- a/math/rotate3dZ.hlsl
+++ b/math/rotate3dZ.hlsl
@@ -10,8 +10,10 @@ license:
 #ifndef FNC_ROTATE3DZ
 #define FNC_ROTATE3DZ
 float3x3 rotate3dZ(const in float r){
-    return float3x3(float3(cos(r),-sin(r),0.),
-                    float3(sin(r),cos(r),0.),
+    float c = cos(r);
+    float s = sin(r);
+    return float3x3(float3(c,-s,0.),
+                    float3(s,c,0.),
                     float3(0.,0.,1.));
 }
 #endif

--- a/math/rotate4d.glsl
+++ b/math/rotate4d.glsl
@@ -14,9 +14,10 @@ mat4 rotate4d(in vec3 a, const in float r) {
     float s = sin(r);
     float c = cos(r);
     float oc = 1.0 - c;
-    return mat4(oc * a.x * a.x + c,         oc * a.x * a.y - a.z * s,   oc * a.z * a.x + a.y * s,   0.0,
-                oc * a.x * a.y + a.z * s,   oc * a.y * a.y + c,         oc * a.y * a.z - a.x * s,   0.0,
-                oc * a.z * a.x - a.y * s,   oc * a.y * a.z + a.x * s,   oc * a.z * a.z + c,         0.0,
-                0.0,                        0.0,                        0.0,                        1.0);
+    vec4 col1 = vec4(oc * a.x * a.x + c, oc * a.x * a.y + a.z * s, oc * a.z * a.x - a.y * s, 0.0);
+    vec4 col2 = vec4(oc * a.x * a.y - a.z * s, oc * a.y * a.y + c, oc * a.y * a.z + a.x * s, 0.0);
+    vec4 col3 = vec4(oc * a.z * a.x + a.y * s, oc * a.y * a.z - a.x * s, oc * a.z * a.z + c, 0.0);
+    vec3 col4 = vec4(0.0, 0.0, 0.0, 1.0);
+    return mat4(col1, col2, col3, col4);
 }
 #endif

--- a/math/rotate4d.glsl
+++ b/math/rotate4d.glsl
@@ -17,7 +17,7 @@ mat4 rotate4d(in vec3 a, const in float r) {
     vec4 col1 = vec4(oc * a.x * a.x + c, oc * a.x * a.y + a.z * s, oc * a.z * a.x - a.y * s, 0.0);
     vec4 col2 = vec4(oc * a.x * a.y - a.z * s, oc * a.y * a.y + c, oc * a.y * a.z + a.x * s, 0.0);
     vec4 col3 = vec4(oc * a.z * a.x + a.y * s, oc * a.y * a.z - a.x * s, oc * a.z * a.z + c, 0.0);
-    vec3 col4 = vec4(0.0, 0.0, 0.0, 1.0);
+    vec4 col4 = vec4(0.0, 0.0, 0.0, 1.0);
     return mat4(col1, col2, col3, col4);
 }
 #endif

--- a/math/rotate4dX.glsl
+++ b/math/rotate4dX.glsl
@@ -10,9 +10,11 @@ license:
 #ifndef FNC_ROTATE4DX
 #define FNC_ROTATE4DX
 mat4 rotate4dX(const in float r){
+    float c = cos(r);
+    float s = sin(r);
     return mat4(vec4(1.,0.,0.,0),
-                vec4(0.,cos(r),-sin(r),0.),
-                vec4(0.,sin(r),cos(r),0.),
+                vec4(0.,c,s,0.),
+                vec4(0.,-s,c,0.),
                 vec4(0.,0.,0.,1.));
 }
 #endif

--- a/math/rotate4dX.hlsl
+++ b/math/rotate4dX.hlsl
@@ -14,7 +14,7 @@ float4x4 rotate4dX(const in float r){
     float s = sin(r);
     return float4x4(float4(1.,0.,0.,0),
                     float4(0.,c,-s,0.),
-                    float4(0.,s,c),0.),
+                    float4(0.,s,c,0.),
                     float4(0.,0.,0.,1.));
 }
 #endif

--- a/math/rotate4dX.hlsl
+++ b/math/rotate4dX.hlsl
@@ -9,10 +9,12 @@ license:
 
 #ifndef FNC_ROTATE4DX
 #define FNC_ROTATE4DX
-float4x4 rotate4dX(const in float phi){
+float4x4 rotate4dX(const in float r){
+    float c = cos(r);
+    float s = sin(r);
     return float4x4(float4(1.,0.,0.,0),
-                    float4(0.,cos(phi),-sin(phi),0.),
-                    float4(0.,sin(phi),cos(phi),0.),
+                    float4(0.,c,-s,0.),
+                    float4(0.,s,c),0.),
                     float4(0.,0.,0.,1.));
 }
 #endif

--- a/math/rotate4dY.glsl
+++ b/math/rotate4dY.glsl
@@ -10,9 +10,11 @@ license:
 #ifndef FNC_ROTATE4DY
 #define FNC_ROTATE4DY
 mat4 rotate4dY(in float r){
-    return mat4(vec4(cos(r),0.,-sin(r),0),
+    float c = cos(r);
+    float s = sin(r);
+    return mat4(vec4(c,0.,-s,0),
                 vec4(0.,1.,0.,0.),
-                vec4(sin(r),0.,cos(r),0.),
+                vec4(s,0.,c,0.),
                 vec4(0.,0.,0.,1.));
 }
 #endif

--- a/math/rotate4dY.hlsl
+++ b/math/rotate4dY.hlsl
@@ -9,10 +9,12 @@ license:
 
 #ifndef FNC_ROTATE4DY
 #define FNC_ROTATE4DY
-float4x4 rotate4dY(in float theta){
-    return float4x4(float4(cos(theta),0.,-sin(theta),0),
+float4x4 rotate4dY(in float r){
+    float c = cos(r);
+    float s = sin(r);
+    return float4x4(float4(c,0.,s,0),
                     float4(0.,1.,0.,0.),
-                    float4(sin(theta),0.,cos(theta),0.),
+                    float4(-s,0.,c,0.),
                     float4(0.,0.,0.,1.));
 }
 #endif

--- a/math/rotate4dZ.glsl
+++ b/math/rotate4dZ.glsl
@@ -10,8 +10,10 @@ license:
 #ifndef FNC_ROTATE4DZ
 #define FNC_ROTATE4DZ
 mat4 rotate4dZ(in float r){
-    return mat4(vec4(cos(r),-sin(r),0.,0),
-                vec4(sin(r),cos(r),0.,0.),
+    float c = cos(r);
+    float s = sin(r);
+    return mat4(vec4(cos(r),sin(r),0.,0),
+                vec4(-sin(r),cos(r),0.,0.),
                 vec4(0.,0.,1.,0.),
                 vec4(0.,0.,0.,1.));
 }

--- a/math/rotate4dZ.hlsl
+++ b/math/rotate4dZ.hlsl
@@ -9,9 +9,11 @@ license:
 
 #ifndef FNC_ROTATE4DZ
 #define FNC_ROTATE4DZ
-float4x4 rotate4dZ(in float psi){
-    return float4x4(float4(cos(psi),-sin(psi),0.,0),
-                    float4(sin(psi),cos(psi),0.,0.),
+float4x4 rotate4dZ(in float r){
+    float c = cos(r);
+    float s = sin(r);
+    return float4x4(float4(c,-s,0.,0),
+                    float4(s,c,0.,0.),
                     float4(0.,0.,1.,0.),
                     float4(0.,0.,0.,1.));
 }


### PR DESCRIPTION
GLSL rotate functions were incorrectly transposed.
I took the opportunity to optimise both the GLSL and HLSL versions.
For reference the rotation matrices are (Source: [Wikipedia](https://en.wikipedia.org/wiki/Rotation_matrix)):
I think I got it all right, but @patriciogonzalezvivo please feel free to double-check.

### 2D

$$R(\theta) = \begin{bmatrix}
\cos\theta & -\sin\theta \\
\sin\theta & \cos\theta
\end{bmatrix}$$

### 3D

$$\begin{bmatrix}
1 & 0 & 0 \\
0 & \cos\theta & -\sin\theta \\
0 & \sin\theta & \cos\theta
\end{bmatrix}_x$$

$$\begin{bmatrix} \cos\theta & 0 & \sin\theta \\
0 & 1 & 0 \\
-\sin\theta & 0 & \cos\theta
\end{bmatrix}_y$$

$$\begin{bmatrix}
\cos\theta & -\sin\theta & 0 \\
\sin\theta & \cos\theta & 0 \\
0 & 0 & 1
\end{bmatrix}_z$$

### Axis-angle 
(sorry, too lazy to type this in Latex)
![image](https://github.com/user-attachments/assets/ee532050-4760-4e4d-b790-9179873e9f37)

### GLSL Constructors
GLSL matrices constructors are column-major.
```glsl
mat3(
  vec3 col1,    // first column
  vec3 col2,    // second column
  vec3 col3);   // third column
``` 

### HLSL Constructors
HLSL matrices constructors  are row-major.
```hlsl
float3x3(
  float3 row1,    // first row
  float3 row2,    // second row
  float3 row3);   // third row
``` 

