### PR TITLE
fix bug in worley impl

### DIFF
--- a/generative/worley.wgsl
+++ b/generative/worley.wgsl
@@ -22,15 +22,15 @@ fn worley22(p: vec2f) -> vec2f {
     let n = floor( p );
     let f = fract( p );
 
-    let distF1 = 1.0;
-    let distF2 = 1.0;
-    let off1 = vec2(0.0); 
-    let pos1 = vec2(0.0);
-    let off2 = vec2(0.0);
-    let pos2 = vec2(0.0);
-    for( int j= -1; j <= 1; j++ ) {
-        for( int i=-1; i <= 1; i++ ) {	
-            let  g = vec2(i,j);
+    var distF1 = 1.0;
+    var distF2 = 1.0;
+    var off1 = vec2(0.0); 
+    var pos1 = vec2(0.0);
+    var off2 = vec2(0.0);
+    var pos2 = vec2(0.0);
+    for(var j = -1; j <= 1; j++) {
+        for(var i = -1; i <= 1; i++) {	
+            let  g = vec2(f32(i), f32(j));
             let  o = random22( n + g ) * WORLEY_JITTER;
             let  p = g + o;
             let d = distEuclidean2(p, f);
@@ -53,22 +53,22 @@ fn worley22(p: vec2f) -> vec2f {
     return vec2(distF1, distF2);
 }
 
-fn worley2(p: vec2f) -> f32 { return 1.0-worley2(p).x; }
+fn worley2(p: vec2f) -> f32 { return 1.0-worley22(p).x; }
 
 fn worley32(p: vec3f) -> vec2f {
     let n = floor( p );
     let f = fract( p );
 
-    let distF1 = 1.0;
-    let distF2 = 1.0;
-    let off1 = vec3(0.0);
-    let pos1 = vec3(0.0);
-    let off2 = vec3(0.0);
-    let pos2 = vec3(0.0);
-    for( int k = -1; k <= 1; k++ ) {
-        for( int j= -1; j <= 1; j++ ) {
-            for( int i=-1; i <= 1; i++ ) {	
-                let  g = vec3(i,j,k);
+    var distF1 = 1.0;
+    var distF2 = 1.0;
+    var off1 = vec3(0.0);
+    var pos1 = vec3(0.0);
+    var off2 = vec3(0.0);
+    var pos2 = vec3(0.0);
+    for(var k = -1; k <= 1; k++) {
+        for(var j = -1; j <= 1; j++) {
+            for(var i=-1; i <= 1; i++) {	
+                let  g = vec3(f32(i), f32(j), f32(k));
                 let  o = random33( n + g ) * WORLEY_JITTER;
                 let  p = g + o;
                 let d = distEuclidean3(p, f);
@@ -92,4 +92,4 @@ fn worley32(p: vec3f) -> vec2f {
     return vec2(distF1, distF2);
 }
 
-fn worley3(p: vec3f) -> f32 { return 1.0-worley2(p).x; }
+fn worley3(p: vec3f) -> f32 { return 1.0-worley32(p).x; }

--- a/math/dist.wgsl
+++ b/math/dist.wgsl
@@ -28,6 +28,6 @@ fn distMinkowski2(a: vec2f, b: vec2f) -> f32 { return  pow(pow(abs(a.x - b.x), D
 fn distMinkowski3(a: vec3f, b: vec3f) -> f32 { return  pow(pow(abs(a.x - b.x), DIST_MINKOWSKI_P) + pow(abs(a.y - b.y), DIST_MINKOWSKI_P) + pow(abs(a.z - b.z), DIST_MINKOWSKI_P), 1.0 / DIST_MINKOWSKI_P); }
 fn distMinkowski4(a: vec4f, b: vec4f) -> f32 { return  pow(pow(abs(a.x - b.x), DIST_MINKOWSKI_P) + pow(abs(a.y - b.y), DIST_MINKOWSKI_P) + pow(abs(a.z - b.z), DIST_MINKOWSKI_P) + pow(abs(a.w - b.w), DIST_MINKOWSKI_P), 1.0 / DIST_MINKOWSKI_P); }
 
-fn dist2(a: vec2f, b: vec2f) -> f32 { return distEuclidean(a, b); }
-fn dist3(a: vec3f, b: vec3f) -> f32 { return distEuclidean(a, b); }
-fn dist4(a: vec4f, b: vec4f) -> f32 { return distEuclidean(a, b); }
+fn dist2(a: vec2f, b: vec2f) -> f32 { return distEuclidean2(a, b); }
+fn dist3(a: vec3f, b: vec3f) -> f32 { return distEuclidean3(a, b); }
+fn dist4(a: vec4f, b: vec4f) -> f32 { return distEuclidean4(a, b); }


### PR DESCRIPTION
Tested, properly, issues were:
- `let` vs `var` bindings for mutable variables
- `dist` function calls non-existent overloaded function from glsl impl
- `worley2`, `worley3` call wrong function
![image](https://github.com/user-attachments/assets/e22ff32a-a119-4c1d-9190-9e3df3bd89a6)
