### PR TITLE
Feature/metal - some sampler + filter additions 

### DIFF
--- a/filter/boxBlur.msl
+++ b/filter/boxBlur.msl
@@ -1,0 +1,78 @@
+#include "../sampler.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: |
+    Given a texture it performs a moving average or box blur. 
+    Which simply averages the pixel values in a KxK window. 
+    This is a very common image processing technique that can be used to smooth out noise.
+use: boxBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset)
+options:
+    - BOXBLUR_2D: default to 1D
+    - BOXBLUR_ITERATIONS: default 3
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of msl (texture2D(...) or texture(...))
+examples:
+    - /shaders/filter_boxBlur2D.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef BOXBLUR_ITERATIONS
+#define BOXBLUR_ITERATIONS 3
+#endif
+
+#ifndef BOXBLUR_TYPE
+#define BOXBLUR_TYPE float4
+#endif
+
+#ifndef BOXBLUR_SAMPLER_FNC
+#define BOXBLUR_SAMPLER_FNC(TEX, UV) SAMPLER_FNC(TEX, UV)
+#endif
+
+#include "boxBlur/1D.msl"
+#include "boxBlur/2D.msl"
+#include "boxBlur/2D_fast9.msl"
+
+#ifndef FNC_BOXBLUR
+#define FNC_BOXBLUR
+BOXBLUR_TYPE boxBlur13(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef BOXBLUR_2D
+  return boxBlur2D(tex, st, offset, 7);
+#else
+  return boxBlur1D(tex, st, offset, 7);
+#endif
+}
+
+BOXBLUR_TYPE boxBlur9(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef BOXBLUR_2D
+  return boxBlur2D_fast9(tex, st, offset);
+#else
+  return boxBlur1D(tex, st, offset, 5);
+#endif
+}
+
+BOXBLUR_TYPE boxBlur5(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef BOXBLUR_2D
+  return boxBlur2D(tex, st, offset, 3);
+#else
+  return boxBlur1D(tex, st, offset, 3);
+#endif
+}
+
+BOXBLUR_TYPE boxBlur(SAMPLER_TYPE tex, float2 st, float2 offset, const int kernelSize) {
+#ifdef BOXBLUR_2D
+  return boxBlur2D(tex, st, offset, kernelSize);
+#else
+  return boxBlur1D(tex, st, offset, kernelSize);
+#endif
+}
+
+BOXBLUR_TYPE boxBlur(SAMPLER_TYPE tex, float2 st, float2 offset) {
+  #ifdef BOXBLUR_2D
+    return boxBlur2D(tex, st, offset, BOXBLUR_ITERATIONS);
+  #else
+    return boxBlur1D(tex, st, offset, BOXBLUR_ITERATIONS);
+  #endif
+}
+#endif

--- a/filter/boxBlur/1D.msl
+++ b/filter/boxBlur/1D.msl
@@ -1,0 +1,63 @@
+#include "../../sampler.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: Simple one dimentional box blur, to be applied in two passes
+use: boxBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of msl (texture2D(...) or texture(...))
+    - BOXBLUR1D_TYPE: default is float4
+    - BOXBLUR1D_SAMPLER_FNC(TEX, UV): default texture2D(tex, TEX, UV)
+    - BOXBLUR1D_KERNELSIZE: Use only for WebGL 1.0 and OpenGL ES 2.0 . For example RaspberryPis is not happy with dynamic loops. Default is 'kernelSize'
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef BOXBLUR1D_TYPE
+#ifdef BOXBLUR_TYPE
+#define BOXBLUR1D_TYPE BOXBLUR_TYPE
+#else
+#define BOXBLUR1D_TYPE float4
+#endif
+#endif
+
+#ifndef BOXBLUR1D_SAMPLER_FNC
+#ifdef BOXBLUR_SAMPLER_FNC
+#define BOXBLUR1D_SAMPLER_FNC(TEX, UV) BOXBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define BOXBLUR1D_SAMPLER_FNC(TEX, UV) SAMPLER_FNC(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_BOXBLUR1D
+#define FNC_BOXBLUR1D
+BOXBLUR1D_TYPE boxBlur1D(SAMPLER_TYPE tex, float2 st, float2 offset, const int kernelSize) {
+    BOXBLUR1D_TYPE color = BOXBLUR1D_TYPE(0.);
+    
+    #ifndef BOXBLUR1D_KERNELSIZE
+    
+    #if defined(PLATFORM_WEBGL)
+    #define BOXBLUR1D_KERNELSIZE 20
+    float kernelSizef = float(kernelSize);
+    #else
+    #define BOXBLUR1D_KERNELSIZE kernelSize
+    float kernelSizef = float(BOXBLUR1D_KERNELSIZE);
+    #endif
+
+    #else
+    float kernelSizef = float(BOXBLUR1D_KERNELSIZE);
+    #endif
+
+    float weight = 1. / kernelSizef;
+    for (int i = 0; i < BOXBLUR1D_KERNELSIZE; i++) {
+        #if defined(PLATFORM_WEBGL)
+        if (i >= kernelSize)
+            break;
+        #endif
+        float x = -.5 * (kernelSizef - 1.) + float(i);
+        color += BOXBLUR1D_SAMPLER_FNC(tex, st + offset * x ) * weight;
+    }
+    return color;
+}
+#endif

--- a/filter/boxBlur/2D.msl
+++ b/filter/boxBlur/2D.msl
@@ -1,0 +1,75 @@
+#include "../../sampler.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: Simple two dimentional box blur, so can be apply in a single pass
+use: boxBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - BOXBLUR2D_TYPE: Default `float4`
+    - BOXBLUR2D_SAMPLER_FNC(TEX, UV): default is `texture2D(tex, TEX, UV)`
+    - BOXBLUR2D_KERNELSIZE: Use only for WebGL 1.0 and OpenGL ES 2.0 . For example RaspberryPis is not happy with dynamic loops. Default is 'kernelSize'
+examples:
+    - /shaders/filter_boxBlur2D.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef BOXBLUR2D_TYPE
+#ifdef BOXBLUR_TYPE
+#define BOXBLUR2D_TYPE BOXBLUR_TYPE
+#else
+#define BOXBLUR2D_TYPE float4
+#endif
+#endif
+
+#ifndef BOXBLUR2D_SAMPLER_FNC
+#ifdef BOXBLUR_SAMPLER_FNC
+#define BOXBLUR2D_SAMPLER_FNC(TEX, UV) BOXBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define BOXBLUR2D_SAMPLER_FNC(TEX, UV) SAMPLER_FNC(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_BOXBLUR2D
+#define FNC_BOXBLUR2D
+BOXBLUR2D_TYPE boxBlur2D(SAMPLER_TYPE tex, float2 st, float2 pixel, const int kernelSize) {
+    BOXBLUR2D_TYPE color = BOXBLUR2D_TYPE(0.);
+
+    #ifndef BOXBLUR2D_KERNELSIZE
+
+    #if defined(PLATFORM_WEBGL)
+    #define BOXBLUR2D_KERNELSIZE 20
+    float kernelSizef = float(kernelSize);
+    #else
+    #define BOXBLUR2D_KERNELSIZE kernelSize
+    float kernelSizef = float(BOXBLUR2D_KERNELSIZE);
+    #endif
+
+    #else
+    float kernelSizef = float(BOXBLUR2D_KERNELSIZE);
+    #endif
+
+    float accumWeight = 0.;
+    float kernelSize2 = kernelSizef * kernelSizef;
+    float weight = 1. / kernelSize2;
+
+    for (int j = 0; j < BOXBLUR2D_KERNELSIZE; j++) {
+        #if defined(PLATFORM_WEBGL)
+        if (j >= kernelSize)
+            break;
+        #endif
+        float y = -.5 * (kernelSizef - 1.) + float(j);
+        for (int i = 0; i < BOXBLUR2D_KERNELSIZE; i++) {
+            #if defined(PLATFORM_WEBGL)
+            if (i >= kernelSize)
+                break;
+            #endif
+            float x = -.5 * (kernelSizef - 1.) + float(i);
+            color += BOXBLUR2D_SAMPLER_FNC(tex, st + float2(x, y) * pixel) * weight;
+        }
+    }
+    return color;
+}
+#endif

--- a/filter/boxBlur/2D_fast9.msl
+++ b/filter/boxBlur/2D_fast9.msl
@@ -1,0 +1,48 @@
+#include "../../sampler.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo, Anton Marini
+description: Simple two dimentional box blur, so can be apply in a single pass
+use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of msl (texture2D(...) or texture(...))
+    - BOXBLUR2D_FAST9_TYPE: Default is `float4`
+    - BOXBLUR2D_FAST9_SAMPLER_FNC(TEX, UV): Default is `texture2D(tex, TEX, UV)`
+examples:
+    - /shaders/filter_boxBlur2D.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef BOXBLUR2D_FAST9_TYPE
+#ifdef BOXBLUR_TYPE
+#define BOXBLUR2D_FAST9_TYPE BOXBLUR_TYPE
+#else
+#define BOXBLUR2D_FAST9_TYPE float4
+#endif
+#endif
+
+#ifndef BOXBLUR2D_FAST9_SAMPLER_FNC
+#ifdef BOXBLUR_SAMPLER_FNC
+#define BOXBLUR2D_FAST9_SAMPLER_FNC(TEX, UV) BOXBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define BOXBLUR2D_FAST9_SAMPLER_FNC(TEX, UV) SAMPLER_FNC(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_BOXBLUR2D_FAST9
+#define FNC_BOXBLUR2D_FAST9
+BOXBLUR2D_FAST9_TYPE boxBlur2D_fast9(SAMPLER_TYPE tex, float2 st, float2 offset) {
+    BOXBLUR2D_FAST9_TYPE color = BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st);          // center
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(-offset.x, offset.y));  // tleft
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(-offset.x, 0.));        // left
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(-offset.x, -offset.y)); // bleft
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(0., offset.y));         // top
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(0., -offset.y));        // bottom
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + offset);                     // tright
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(offset.x, 0.));         // right
+    color += BOXBLUR2D_FAST9_SAMPLER_FNC(tex, st + float2(offset.x, -offset.y));  // bright
+    return color * 0.1111111111; // 1./9.
+}
+#endif

--- a/filter/gaussianBlur.msl
+++ b/filter/gaussianBlur.msl
@@ -1,0 +1,75 @@
+#include "../sampler.msl"
+
+/*
+contributors:
+    - Matt DesLauriers
+    - Patricio Gonzalez Vivo
+description: Adapted versions from 5, 9 and 13 gaussian fast blur from https://github.com/Jam3/glsl-fast-gaussian-blur
+use: gaussianBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction [, const int kernelSize])
+options:
+    - GAUSSIANBLUR_AMOUNT: gaussianBlur5 gaussianBlur9 gaussianBlur13
+    - GAUSSIANBLUR_2D: default to 1D
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+examples:
+    - /shaders/filter_gaussianBlur2D.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef GAUSSIANBLUR_AMOUNT
+#define GAUSSIANBLUR_AMOUNT gaussianBlur13
+#endif
+
+#ifndef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR_TYPE float4
+#endif
+
+#ifndef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR_SAMPLER_FNC(TEX, UV) SAMPLER_FNC(TEX, UV)
+#endif
+
+#include "gaussianBlur/2D.msl"
+#include "gaussianBlur/1D.msl"
+#include "gaussianBlur/1D_fast13.msl"
+#include "gaussianBlur/1D_fast9.msl"
+#include "gaussianBlur/1D_fast5.msl"
+
+#ifndef FNC_GAUSSIANBLUR
+#define FNC_GAUSSIANBLUR
+GAUSSIANBLUR_TYPE gaussianBlur13(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef GAUSSIANBLUR_2D
+    return gaussianBlur2D(tex, st, offset, 7);
+#else
+    return gaussianBlur1D_fast13(tex, st, offset);
+#endif
+}
+
+GAUSSIANBLUR_TYPE gaussianBlur9(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef GAUSSIANBLUR_2D
+    return gaussianBlur2D(tex, st, offset, 5);
+#else
+    return gaussianBlur1D_fast9(tex, st, offset);
+#endif
+}
+
+GAUSSIANBLUR_TYPE gaussianBlur5(SAMPLER_TYPE tex, float2 st, float2 offset) {
+#ifdef GAUSSIANBLUR_2D
+    return gaussianBlur2D(tex, st, offset, 3);
+#else
+    return gaussianBlur1D_fast5(tex, st, offset);
+#endif
+}
+
+GAUSSIANBLUR_TYPE gaussianBlur(SAMPLER_TYPE tex, float2 st, float2 offset, const int kernelSize) {
+#ifdef GAUSSIANBLUR_2D
+    return gaussianBlur2D(tex, st, offset, kernelSize);
+#else
+    return gaussianBlur1D(tex, st, offset, kernelSize);
+#endif
+}
+
+GAUSSIANBLUR_TYPE gaussianBlur(SAMPLER_TYPE tex, float2 st, float2 offset) {
+    return GAUSSIANBLUR_AMOUNT(tex, st, offset);
+}
+#endif

--- a/filter/gaussianBlur/1D.msl
+++ b/filter/gaussianBlur/1D.msl
@@ -1,0 +1,76 @@
+#include "../../math/gaussian.msl"
+#include "../../sample/clamp2edge.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: One dimension Gaussian Blur to be applied two passes
+use: gaussianBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction , const int kernelSize)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - GAUSSIANBLUR1D_TYPE: null
+    - GAUSSIANBLUR1D_SAMPLER_FNC(TEX, UV): null
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef GAUSSIANBLUR1D_TYPE
+#ifdef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR1D_TYPE GAUSSIANBLUR_TYPE
+#else
+#define GAUSSIANBLUR1D_TYPE float4
+#endif
+#endif
+
+#ifndef GAUSSIANBLUR1D_SAMPLER_FNC
+#ifdef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR1D_SAMPLER_FNC(TEX, UV) GAUSSIANBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define GAUSSIANBLUR1D_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_GAUSSIANBLUR1D
+#define FNC_GAUSSIANBLUR1D
+
+#ifdef PLATFORM_WEBGL
+
+GAUSSIANBLUR1D_TYPE gaussianBlur1D(SAMPLER_TYPE tex,float2 st,float2 offset,const int kernelSize){
+    GAUSSIANBLUR1D_TYPE accumColor = GAUSSIANBLUR1D_TYPE(0.0);
+
+    float kernelSizef = float(kernelSize);
+    float accumWeight = 0.0;
+    const float k = 0.39894228;// 1 / sqrt(2*PI)
+    for (int i = 0; i < 16; i++) {
+        if( i >= kernelSize)
+            break;
+        float x = -0.5 * (float(kernelSize) - 1.0)+float(i);
+        float weight = (k/float(kernelSize)) * gaussian(x, kernelSizef);
+        GAUSSIANBLUR1D_TYPE tex = GAUSSIANBLUR1D_SAMPLER_FNC(tex, st + x * offset);
+        accumColor += weight * tex;
+        accumWeight += weight;
+    }
+    return accumColor/accumWeight;
+}
+
+#else
+
+GAUSSIANBLUR1D_TYPE gaussianBlur1D(SAMPLER_TYPE tex,float2 st,float2 offset,const int kernelSize){
+    GAUSSIANBLUR1D_TYPE accumColor=GAUSSIANBLUR1D_TYPE(0.);
+
+    float kernelSizef = float(kernelSize);
+    
+    float accumWeight = 0.0;
+    const float k = 0.39894228;// 1 / sqrt(2*PI)
+    for (int i = 0; i < kernelSize; i++) {
+        float x = -0.5 * ( kernelSizef -1.0) + float(i);
+        float weight = (k / kernelSizef) * gaussian(x, kernelSizef);
+        GAUSSIANBLUR1D_TYPE t = GAUSSIANBLUR1D_SAMPLER_FNC(tex, st + x * offset);
+        accumColor += weight * t;
+        accumWeight += weight;
+    }
+    return accumColor/accumWeight;
+}
+#endif
+
+#endif

--- a/filter/gaussianBlur/1D_fast13.msl
+++ b/filter/gaussianBlur/1D_fast13.msl
@@ -1,0 +1,46 @@
+#include "../../sample/clamp2edge.msl"
+
+/*
+function: gaussianBlur1D_fast13
+contributors: Matt DesLauriers
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+use: gaussianBlur1D_fast13(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - GAUSSIANBLUR1D_FAST13_TYPE
+    - GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(TEX, UV)
+*/
+
+#ifndef GAUSSIANBLUR1D_FAST13_TYPE
+#ifdef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR1D_FAST13_TYPE GAUSSIANBLUR_TYPE
+#else
+#define GAUSSIANBLUR1D_FAST13_TYPE float4
+#endif
+#endif
+
+#ifndef GAUSSIANBLUR1D_FAST13_SAMPLER_FNC
+#ifdef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(TEX, UV) GAUSSIANBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_GAUSSIANBLUR1D_FAST13
+#define FNC_GAUSSIANBLUR1D_FAST13
+GAUSSIANBLUR1D_FAST13_TYPE gaussianBlur1D_fast13(SAMPLER_TYPE tex, float2 st, float2 offset) {
+    GAUSSIANBLUR1D_FAST13_TYPE color = GAUSSIANBLUR1D_FAST13_TYPE(0.);
+    float2 off1 = float2(1.411764705882353) * offset;
+    float2 off2 = float2(3.2941176470588234) * offset;
+    float2 off3 = float2(5.176470588235294) * offset;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st) * .1964825501511404;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st + (off1)) * .2969069646728344;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st - (off1)) * .2969069646728344;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st + (off2)) * .09447039785044732;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st - (off2)) * .09447039785044732;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st + (off3)) * .010381362401148057;
+    color += GAUSSIANBLUR1D_FAST13_SAMPLER_FNC(tex, st - (off3)) * .010381362401148057;
+    return color;
+}
+#endif

--- a/filter/gaussianBlur/1D_fast5.msl
+++ b/filter/gaussianBlur/1D_fast5.msl
@@ -1,0 +1,39 @@
+#include "../../sample/clamp2edge.msl"
+
+/*
+contributors: Matt DesLauriers
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+use: gaussianBlur1D_fast5(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - GAUSSIANBLUR1D_FAST5_TYPE
+    - GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(TEX, UV)
+*/
+
+#ifndef GAUSSIANBLUR1D_FAST5_TYPE
+#ifdef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR1D_FAST5_TYPE GAUSSIANBLUR_TYPE
+#else
+#define GAUSSIANBLUR1D_FAST5_TYPE float4
+#endif
+#endif
+
+#ifndef GAUSSIANBLUR1D_FAST5_SAMPLER_FNC
+#ifdef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(TEX, UV) GAUSSIANBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_GAUSSIANBLUR1D_FAST5
+#define FNC_GAUSSIANBLUR1D_FAST5
+GAUSSIANBLUR1D_FAST5_TYPE gaussianBlur1D_fast5(SAMPLER_TYPE tex, float2 st, float2 offset) {
+    GAUSSIANBLUR1D_FAST5_TYPE color = GAUSSIANBLUR1D_FAST5_TYPE(0.);
+    float2 off1 = float2(1.3333333333333333) * offset;
+    color += GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(tex, st) * .29411764705882354;
+    color += GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(tex, st + (off1)) * .35294117647058826;
+    color += GAUSSIANBLUR1D_FAST5_SAMPLER_FNC(tex, st - (off1)) * .35294117647058826;
+    return color;
+}
+#endif

--- a/filter/gaussianBlur/1D_fast9.msl
+++ b/filter/gaussianBlur/1D_fast9.msl
@@ -1,0 +1,42 @@
+#include "../../sample/clamp2edge.msl"
+
+/*
+contributors: Matt DesLauriers
+description: Adapted versions of gaussian fast blur 13 from https://github.com/Jam3/glsl-fast-gaussian-blur
+use: gaussianBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - GAUSSIANBLUR1D_FAST9_TYPE
+    - GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(TEX, UV)
+*/
+
+#ifndef GAUSSIANBLUR1D_FAST9_TYPE
+#ifdef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR1D_FAST9_TYPE GAUSSIANBLUR_TYPE
+#else
+#define GAUSSIANBLUR1D_FAST9_TYPE float4
+#endif
+#endif
+
+#ifndef GAUSSIANBLUR1D_FAST9_SAMPLER_FNC
+#ifdef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(TEX, UV) GAUSSIANBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_GAUSSIANBLUR1D_FAST9
+#define FNC_GAUSSIANBLUR1D_FAST9
+GAUSSIANBLUR1D_FAST9_TYPE gaussianBlur1D_fast9(SAMPLER_TYPE tex, float2 st, float2 offset) {
+    GAUSSIANBLUR1D_FAST9_TYPE color = GAUSSIANBLUR1D_FAST9_TYPE(0.);
+    float2 off1 = float2(1.3846153846) * offset;
+    float2 off2 = float2(3.2307692308) * offset;
+    color += GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(tex, st) * .2270270270;
+    color += GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(tex, st + (off1)) * .3162162162;
+    color += GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(tex, st - (off1)) * .3162162162;
+    color += GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(tex, st + (off2)) * .0702702703;
+    color += GAUSSIANBLUR1D_FAST9_SAMPLER_FNC(tex, st - (off2)) * .0702702703;
+    return color;
+}
+#endif

--- a/filter/gaussianBlur/2D.msl
+++ b/filter/gaussianBlur/2D.msl
@@ -1,0 +1,77 @@
+#include "../../math/gaussian.msl"
+#include "../../sample/clamp2edge.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: Two dimension Gaussian Blur to be applied only one passes
+use: gaussianBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction, const int kernelSize)
+options:
+    - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
+    - GAUSSIANBLUR2D_TYPE: Default `float4`
+    - GAUSSIANBLUR2D_SAMPLER_FNC(TEX, UV): Default `texture2D(tex, TEX, UV)`
+    - GAUSSIANBLUR2D_KERNELSIZE: Use only for WebGL 1.0 and OpenGL ES 2.0 . For example  RaspberryPis is not happy with dynamic loops. Default is 'kernelSize'
+examples:
+    - /shaders/filter_gaussianBlur2D.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef GAUSSIANBLUR2D_TYPE
+#ifdef GAUSSIANBLUR_TYPE
+#define GAUSSIANBLUR2D_TYPE GAUSSIANBLUR_TYPE
+#else
+#define GAUSSIANBLUR2D_TYPE float4
+#endif
+#endif
+
+#ifndef GAUSSIANBLUR2D_SAMPLER_FNC
+#ifdef GAUSSIANBLUR_SAMPLER_FNC
+#define GAUSSIANBLUR2D_SAMPLER_FNC(TEX, UV) GAUSSIANBLUR_SAMPLER_FNC(TEX, UV)
+#else
+#define GAUSSIANBLUR2D_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
+#endif
+#endif
+
+#ifndef FNC_GAUSSIANBLUR2D
+#define FNC_GAUSSIANBLUR2D
+GAUSSIANBLUR2D_TYPE gaussianBlur2D(SAMPLER_TYPE tex, float2 st, float2 offset, const int kernelSize) {
+    GAUSSIANBLUR2D_TYPE accumColor = GAUSSIANBLUR2D_TYPE(0.);
+    
+    #ifndef GAUSSIANBLUR2D_KERNELSIZE
+    
+        #if defined(PLATFORM_WEBGL)
+            #define GAUSSIANBLUR2D_KERNELSIZE 20
+            float kernelSizef = float(kernelSize);
+        #else
+            #define GAUSSIANBLUR2D_KERNELSIZE kernelSize
+            float kernelSizef = float(GAUSSIANBLUR2D_KERNELSIZE);
+        #endif
+
+    #else
+        float kernelSizef = float(GAUSSIANBLUR2D_KERNELSIZE);
+    #endif
+
+    float accumWeight = 0.;
+    const float k = 0.15915494; // 1 / (2*PI)
+    float2 xy = float2(0.0);
+    for (int j = 0; j < GAUSSIANBLUR2D_KERNELSIZE; j++) {
+        #if defined(PLATFORM_WEBGL)
+        if (j >= kernelSize)
+            break;
+        #endif
+        xy.y = -.5 * (kernelSizef - 1.) + float(j);
+        for (int i = 0; i < GAUSSIANBLUR2D_KERNELSIZE; i++) {
+            #if defined(PLATFORM_WEBGL)
+            if (i >= kernelSize)
+                break;
+            #endif
+            xy.x = -0.5 * (kernelSizef - 1.) + float(i);
+            float weight = (k / kernelSizef) * gaussian(xy, kernelSizef);
+            accumColor += weight * GAUSSIANBLUR2D_SAMPLER_FNC(tex, st + xy * offset);
+            accumWeight += weight;
+        }
+    }
+    return accumColor / accumWeight;
+}
+#endif

--- a/math/gaussian.msl
+++ b/math/gaussian.msl
@@ -1,0 +1,18 @@
+/*
+contributors: Patricio Gonzalez Vivo
+description: gaussian coeficient
+use: <float4|float3|float2|float> gaussian(<float> sigma, <float4|float3|float2|float> d)
+examples:
+    - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_gaussian.frag
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef FNC_GAUSSIAN
+#define FNC_GAUSSIAN
+float gaussian(float d, float s) { return exp(-(d*d) / (2.0 * s*s)); }
+float gaussian( float2 d, float s) { return exp(-( d.x*d.x + d.y*d.y) / (2.0 * s*s)); }
+float gaussian( float3 d, float s) { return exp(-( d.x*d.x + d.y*d.y + d.z*d.z ) / (2.0 * s*s)); }
+float gaussian( float4 d, float s) { return exp(-( d.x*d.x + d.y*d.y + d.z*d.z + d.w*d.w ) / (2.0 * s*s)); }
+#endif

--- a/sample/clamp2edge.msl
+++ b/sample/clamp2edge.msl
@@ -1,0 +1,28 @@
+#include "../sampler.msl"
+
+/*
+contributors: Patricio Gonzalez Vivo
+description: fakes a clamp to edge texture
+use: <float4> sampleClamp2edge(<SAMPLER_TYPE> tex, <float2> st [, <float2> texResolution]);
+options:
+    - SAMPLER_FNC(TEX, UV)
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+
+#ifndef FNC_SAMPLECLAMP2EDGE
+#define FNC_SAMPLECLAMP2EDGE
+float4 sampleClamp2edge(SAMPLER_TYPE tex, float2 st, float2 texResolution) {
+    float2 pixel = 1.0/texResolution;
+    return SAMPLER_FNC( tex, clamp(st, pixel, 1.0-pixel) );
+}
+
+float4 sampleClamp2edge(SAMPLER_TYPE tex, float2 st) { 
+    return SAMPLER_FNC( tex, clamp(st, float2(0.01), float2(0.99) ) ); 
+}
+
+float4 sampleClamp2edge(SAMPLER_TYPE tex, float2 st, float edge) { 
+    return SAMPLER_FNC( tex, clamp(st, float2(edge), float2(1.0 - edge) ) ); 
+}
+#endif

--- a/sampler.msl
+++ b/sampler.msl
@@ -1,0 +1,15 @@
+/*
+contributors: Patricio Gonzalez Vivo, Anton Marini
+description: It defines the default sampler type and function for the shader based on the version of GLSL.
+license:
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
+    - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
+*/
+#ifndef SAMPLER_FNC
+#define SAMPLER sampler( min_filter::linear, mag_filter::linear )
+#define SAMPLER_FNC(TEX, UV) TEX.sample(SAMPLER, UV)
+#endif
+
+#ifndef SAMPLER_TYPE
+#define SAMPLER_TYPE texture2d<float>
+#endif

--- a/sampler.msl
+++ b/sampler.msl
@@ -5,8 +5,12 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
-#ifndef SAMPLER_FNC
+
+#ifndef SAMPLER
 #define SAMPLER sampler( min_filter::linear, mag_filter::linear )
+#endif
+
+#ifndef SAMPLER_FNC
 #define SAMPLER_FNC(TEX, UV) TEX.sample(SAMPLER, UV)
 #endif
 


### PR DESCRIPTION
Finally had a moment to work on this.

* had to add a `SAMPLER` which metal uses, which defaults to `sampler( min_filter::linear, mag_filter::linear )`
* set the default texture2d precision to float to keep things in parity with the rest of Lygia. This means that metal shaders need to define their texture as float, not half which is maybe more standard. You can override this by redefining `SAMPLER_TYPE`

Implemented box blur and gaussian blur just to test the waters. 