### PR TITLE
Fixed viewMatrix issue (GLSL) and Raymarching bug (HLSL)

### DIFF
--- a/lighting/raymarch.glsl
+++ b/lighting/raymarch.glsl
@@ -54,8 +54,8 @@ vec4 raymarch(  mat4 viewMatrix, vec2 st
     ) {
                     
     float fov = 1.0 / tan(RAYMARCH_CAMERA_FOV * DEG2RAD * 0.5);
-    vec3 camera = vec3(viewMatrix[0][3], viewMatrix[1][3], viewMatrix[2][3]);
-    vec3 cameraForward = vec3(viewMatrix[0][2], viewMatrix[1][2], viewMatrix[2][2]);
+    vec3 camera = viewMatrix[3].xyz;
+    vec3 cameraForward = viewMatrix[2].xyz;
     mat3 viewMatrix3 = toMat3(viewMatrix);
 
 #if defined(RAYMARCH_MULTISAMPLE)

--- a/lighting/raymarch.hlsl
+++ b/lighting/raymarch.hlsl
@@ -42,10 +42,10 @@ license:
 #define ENG_RAYMARCH
 
 #if defined(RAYMARCH_MULTISAMPLE)
-const float RAYMARCH_MULTISAMPLE_FACTOR = 1.0/float(RAYMARCH_MULTISAMPLE);
+static const float RAYMARCH_MULTISAMPLE_FACTOR = 1.0/float(RAYMARCH_MULTISAMPLE);
 #endif
 
-float4 raymarch(float4x4 viewMatrix, float2 st,
+float4 raymarch(float4x4 viewMatrix, float2 st
 #if RAYMARCH_RETURN >= 1
                 ,out float eyeDepth
 #endif
@@ -55,7 +55,7 @@ float4 raymarch(float4x4 viewMatrix, float2 st,
     ) {
 
     float fov = 1.0 / tan(RAYMARCH_CAMERA_FOV * DEG2RAD * 0.5);
-    float3 cameraPosition = float3(viewMatrix._m03, viewMatrix._m13, viewMatrix._m23);
+    float3 camera = float3(viewMatrix._m03, viewMatrix._m13, viewMatrix._m23);
     float3 cameraForward = float3(viewMatrix._m02, viewMatrix._m12, viewMatrix._m22);
 
 #if defined(RAYMARCH_MULTISAMPLE)
@@ -218,7 +218,7 @@ float4 raymarch(float3 cameraPosition, float3 cameraLookAt, float2 st
     ){
     float4x4 viewMatrix = lookAtView(cameraPosition, cameraLookAt);
 
-    return raymarch(viewMatrix, st, 
+    return raymarch(viewMatrix, st
     #if RAYMARCH_RETURN >= 1
                     ,depth
     #endif

--- a/lighting/raymarch/render.hlsl
+++ b/lighting/raymarch/render.hlsl
@@ -28,7 +28,7 @@ options:
 #ifndef FNC_RAYMARCH_DEFAULT
 #define FNC_RAYMARCH_DEFAULT
 
-float4 raymarchDefaultRender(in float3 rayOrigin, in float3 rayDirection, float3 cameraForward,
+float4 raymarchDefaultRender(in float3 rayOrigin, in float3 rayDirection, float3 cameraForward
 #if RAYMARCH_RETURN != 0
                             ,out float eyeDepth
 #endif
@@ -50,7 +50,7 @@ float4 raymarchDefaultRender(in float3 rayOrigin, in float3 rayDirection, float3
     if (res.valid) {
         res.position = worldPos;
         res.normal = worldNormal;
-        es.ambientOcclusion = raymarchAO(res.position, res.normal);
+        res.ambientOcclusion = raymarchAO(res.position, res.normal);
         res.V = -rayDirection;
         color = RAYMARCH_SHADING_FNC(res);
     }

--- a/space/translate.glsl
+++ b/space/translate.glsl
@@ -9,10 +9,10 @@ use: <mat4> translate(in <mat3> matrix, in <vec3> tranaslation)
 
  mat4 translate(mat3 m, vec3 translation) {
     return mat4(
-        vec4(m[0], translation.x),
-        vec4(m[1], translation.y),
-        vec4(m[2], translation.z),
-        vec4(0.0, 0.0, 0.0, 1.0)
+        vec4(m[0], 0.0),
+        vec4(m[1], 0.0),
+        vec4(m[2], 0.0),
+        vec4(translation, 1.0)
     );
 }
 


### PR DESCRIPTION
* Fixed viewMatrix column order issue in GLSL. This was causing the cameraForward to be incorrectly calculated and breaking eyeDepth.
* Fixed HLSL bug caused by https://github.com/patriciogonzalezvivo/lygia/commit/43fc57f9b645182dcd155052e90fb345ec76f94e. Gentle reminder to always make global `const` variables `static const` in HLSL. Otherwise they will be optimised away by the compiler and cause the shader to silently fail.