### PR TITLE
Minor param refactoring in Raymarch

### DIFF
--- a/lighting/raymarch/ao.glsl
+++ b/lighting/raymarch/ao.glsl
@@ -35,8 +35,9 @@ examples:
 float raymarchAO(in vec3 pos, in vec3 nor) {
     float occ = 0.0;
     float sca = 1.0;
+    const float samplesFactor = 1.0 / float(RAYMARCH_AO_SAMPLES-1);
     for (int i = 0; i < RAYMARCH_AO_SAMPLES; i++) {
-        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) / (RAYMARCH_AO_SAMPLES-1);
+        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) * samplesFactor;
         float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
         sca *= RAYMARCH_AO_FALLOFF;

--- a/lighting/raymarch/ao.glsl
+++ b/lighting/raymarch/ao.glsl
@@ -9,8 +9,24 @@ examples:
     - /shaders/lighting_raymarching.frag
 */
 
-#ifndef RAYMARCH_SAMPLES_AO
-#define RAYMARCH_SAMPLES_AO 5
+#ifndef RAYMARCH_AO_SAMPLES
+#define RAYMARCH_AO_SAMPLES 5
+#endif
+
+#ifndef RAYMARCH_AO_INTENSITY
+#define RAYMARCH_AO_INTENSITY 1.0
+#endif
+
+#ifndef RAYMARCH_AO_MIN_DIST
+#define RAYMARCH_AO_MIN_DIST 0.001
+#endif
+
+#ifndef RAYMARCH_AO_MAX_DIST
+#define RAYMARCH_AO_MAX_DIST 0.2
+#endif
+
+#ifndef RAYMARCH_AO_FALLOFF
+#define RAYMARCH_AO_FALLOFF 0.95
 #endif
 
 #ifndef FNC_RAYMARCH_AO
@@ -19,13 +35,13 @@ examples:
 float raymarchAO(in vec3 pos, in vec3 nor) {
     float occ = 0.0;
     float sca = 1.0;
-    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++) {
-        float h = 0.001 + 0.15 * float(i) / 4.0;
+    for (int i = 0; i < RAYMARCH_AO_SAMPLES; i++) {
+        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) / (RAYMARCH_AO_SAMPLES-1);
         float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
-        sca *= 0.95;
+        sca *= RAYMARCH_AO_FALLOFF;
     }
-    return clamp(1.0 - 1.5 * occ, 0.0, 1.0);
+    return saturate(1.0 - RAYMARCH_AO_INTENSITY * occ);
 }
 
 #endif

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -34,8 +34,9 @@ examples:
 float raymarchAO(in float3 pos, in float3 nor) {
     float occ = 0.0;
     float sca = 1.0;
+    const float samplesFactor = 1.0 / float(RAYMARCH_AO_SAMPLES-1);
     for (int i = 0; i < RAYMARCH_AO_SAMPLES; i++) {
-        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) / (RAYMARCH_AO_SAMPLES-1);
+        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) * samplesFactor;
         float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
         sca *= RAYMARCH_AO_FALLOFF;

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -1,4 +1,4 @@
-#include "map.glsl"
+#include "map.hlsl"
 
 /*
 contributors:  Inigo Quiles

--- a/lighting/raymarch/ao.hlsl
+++ b/lighting/raymarch/ao.hlsl
@@ -1,13 +1,31 @@
-#include "map.hlsl"
+#include "map.glsl"
 
 /*
 contributors:  Inigo Quiles
 description: Calculate Ambient Occlusion. See calcAO in https://www.shadertoy.com/view/lsKcDD
 use: <float> raymarchAO( in <float3> pos, in <float3> nor ) 
+examples:
+    - /shaders/lighting_raymarching.frag
 */
 
-#ifndef RAYMARCH_SAMPLES_AO
-#define RAYMARCH_SAMPLES_AO 5
+#ifndef RAYMARCH_AO_SAMPLES
+#define RAYMARCH_AO_SAMPLES 5
+#endif
+
+#ifndef RAYMARCH_AO_INTENSITY
+#define RAYMARCH_AO_INTENSITY 1.0
+#endif
+
+#ifndef RAYMARCH_AO_MIN_DIST
+#define RAYMARCH_AO_MIN_DIST 0.001
+#endif
+
+#ifndef RAYMARCH_AO_MAX_DIST
+#define RAYMARCH_AO_MAX_DIST 0.2
+#endif
+
+#ifndef RAYMARCH_AO_FALLOFF
+#define RAYMARCH_AO_FALLOFF 0.95
 #endif
 
 #ifndef FNC_RAYMARCH_AO
@@ -16,13 +34,13 @@ use: <float> raymarchAO( in <float3> pos, in <float3> nor )
 float raymarchAO(in float3 pos, in float3 nor) {
     float occ = 0.0;
     float sca = 1.0;
-    for (int i = 0; i < RAYMARCH_SAMPLES_AO; i++) {
-        float h = 0.001 + 0.15 * float(i) / 4.0;
+    for (int i = 0; i < RAYMARCH_AO_SAMPLES; i++) {
+        float h = RAYMARCH_AO_MIN_DIST + RAYMARCH_AO_MAX_DIST * float(i) / (RAYMARCH_AO_SAMPLES-1);
         float d = RAYMARCH_MAP_FNC(pos + h * nor).sdf;
         occ += (h - d) * sca;
-        sca *= 0.95;
+        sca *= RAYMARCH_AO_FALLOFF;
     }
-    return clamp(1.0 - 1.5 * occ, 0.0, 1.0);
+    return saturate(1.0 - RAYMARCH_AO_INTENSITY * occ);
 }
 
 #endif

--- a/lighting/raymarch/normal.glsl
+++ b/lighting/raymarch/normal.glsl
@@ -8,6 +8,10 @@ examples:
     - /shaders/lighting_raymarching.frag
 */
 
+#ifndef RAYMARCH_NORMAL_OFFSET
+#define RAYMARCH_NORMAL_OFFSET 0.0001
+#endif
+
 #ifndef FNC_RAYMARCH_NORMAL
 #define FNC_RAYMARCH_NORMAL
 
@@ -28,7 +32,7 @@ vec3 raymarchNormal(vec3 pos, float e) {
 }
 
 vec3 raymarchNormal( in vec3 pos ) {
-   return raymarchNormal(pos, 0.5773 * 0.0005);
+   return raymarchNormal(pos, RAYMARCH_NORMAL_OFFSET);
 }
 
 #endif

--- a/lighting/raymarch/normal.hlsl
+++ b/lighting/raymarch/normal.hlsl
@@ -6,6 +6,10 @@ description: Calculate normals http://iquilezles.org/www/articles/normalsSDF/nor
 use: <float> raymarchNormal( in <float3> pos ) 
 */
 
+#ifndef RAYMARCH_NORMAL_OFFSET
+#define RAYMARCH_NORMAL_OFFSET 0.0001
+#endif
+
 #ifndef FNC_RAYMARCH_NORMAL
 #define FNC_RAYMARCH_NORMAL
 
@@ -26,7 +30,7 @@ float3 raymarchNormal(float3 pos, float e) {
 }
 
 float3 raymarchNormal( in float3 pos ) {
-   return raymarchNormal(pos, 0.5773 * 0.0005);
+   return raymarchNormal(pos, RAYMARCH_NORMAL_OFFSET);
 }
 
 #endif

--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -13,8 +13,12 @@ examples:
     - /shaders/lighting_raymarching.frag
 */
 
-#ifndef RAYMARCHSOFTSHADOW_ITERATIONS
-#define RAYMARCHSOFTSHADOW_ITERATIONS 64
+#ifndef RAYMARCH_MAX_DIST
+#define RAYMARCH_MAX_DIST 20.0
+#endif
+
+#ifndef RAYMARCH_SOFTSHADOW_ITERATIONS
+#define RAYMARCH_SOFTSHADOW_ITERATIONS 64
 #endif
 
 #ifndef RAYMARCH_SHADOW_MIN_DIST
@@ -39,7 +43,7 @@ float raymarchSoftShadow(vec3 ro, vec3 rd) {
 
     float res = 1.0;
     float t = mint;
-    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
+    for (int i = 0; i < RAYMARCH_SOFTSHADOW_ITERATIONS; i++) {
         if (t >= maxt)
             break;
         float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;

--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -36,13 +36,9 @@ examples:
 float raymarchSoftShadow(vec3 ro, vec3 rd, in float mint, in float maxt, float w) {
     float res = 1.0;
     float t = mint;
-    #if defined(PLATFORM_WEBGL)
     for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
         if (t >= maxt)
             break;
-    #else
-    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++) {
-    #endif
         float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
 

--- a/lighting/raymarch/softShadow.glsl
+++ b/lighting/raymarch/softShadow.glsl
@@ -1,10 +1,9 @@
 #include "map.glsl"
-#include "../../math/saturate.glsl"
 
 /*
 contributors:  Inigo Quiles
 description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
-use: <float> raymarchSoftshadow( in <vec3> ro, in <vec3> rd, in <float> tmin, in <float> tmax) 
+use: <float> raymarchSoftshadow( in <vec3> ro, in <vec3> rd ) 
 options:
     - RAYMARCHSOFTSHADOW_ITERATIONS: shadow quality
     - RAYMARCH_SHADOW_MIN_DIST: minimum shadow distance
@@ -19,11 +18,11 @@ examples:
 #endif
 
 #ifndef RAYMARCH_SHADOW_MIN_DIST
-#define RAYMARCH_SHADOW_MIN_DIST 0.01
+#define RAYMARCH_SHADOW_MIN_DIST 0.005
 #endif
 
 #ifndef RAYMARCH_SHADOW_MAX_DIST
-#define RAYMARCH_SHADOW_MAX_DIST 3.0
+#define RAYMARCH_SHADOW_MAX_DIST RAYMARCH_MAX_DIST
 #endif
 
 #ifndef RAYMARCH_SHADOW_SOLID_ANGLE
@@ -33,7 +32,11 @@ examples:
 #ifndef FNC_RAYMARCH_SOFTSHADOW
 #define FNC_RAYMARCH_SOFTSHADOW
 
-float raymarchSoftShadow(vec3 ro, vec3 rd, in float mint, in float maxt, float w) {
+float raymarchSoftShadow(vec3 ro, vec3 rd) {
+    const float mint = RAYMARCH_SHADOW_MIN_DIST;
+    const float maxt = RAYMARCH_SHADOW_MAX_DIST;
+    const float w = RAYMARCH_SHADOW_SOLID_ANGLE;
+
     float res = 1.0;
     float t = mint;
     for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
@@ -42,15 +45,12 @@ float raymarchSoftShadow(vec3 ro, vec3 rd, in float mint, in float maxt, float w
         float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
 
-        t += clamp(h, 0.005, 0.50);
+        t += clamp(h, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST);
         if (res < -1.0 || t > maxt)
             break;
     }
     res = max(res, -1.0);
     return 0.25 * (1.0 + res) * (1.0 + res) * (2.0 - res);
 }
-
-float raymarchSoftShadow(vec3 ro, vec3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST, RAYMARCH_SHADOW_SOLID_ANGLE); }
-float raymarchSoftShadow(vec3 ro, vec3 rd) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST); }
 
 #endif

--- a/lighting/raymarch/softShadow.hlsl
+++ b/lighting/raymarch/softShadow.hlsl
@@ -3,12 +3,14 @@
 /*
 contributors:  Inigo Quiles
 description: Calculate soft shadows http://iquilezles.org/www/articles/rmshadows/rmshadows.htm
-use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd, in <float> tmin, in <float> tmax)
+use: <float> raymarchSoftshadow( in <float3> ro, in <float3> rd ) 
 options:
     - RAYMARCHSOFTSHADOW_ITERATIONS: shadow quality
     - RAYMARCH_SHADOW_MIN_DIST: minimum shadow distance
     - RAYMARCH_SHADOW_MAX_DIST: maximum shadow distance
     - RAYMARCH_SHADOW_SOLID_ANGLE: light size
+examples:
+    - /shaders/lighting_raymarching.frag
 */
 
 #ifndef RAYMARCHSOFTSHADOW_ITERATIONS
@@ -16,11 +18,11 @@ options:
 #endif
 
 #ifndef RAYMARCH_SHADOW_MIN_DIST
-#define RAYMARCH_SHADOW_MIN_DIST 0.01
+#define RAYMARCH_SHADOW_MIN_DIST 0.005
 #endif
 
 #ifndef RAYMARCH_SHADOW_MAX_DIST
-#define RAYMARCH_SHADOW_MAX_DIST 3.0
+#define RAYMARCH_SHADOW_MAX_DIST RAYMARCH_MAX_DIST
 #endif
 
 #ifndef RAYMARCH_SHADOW_SOLID_ANGLE
@@ -30,7 +32,11 @@ options:
 #ifndef FNC_RAYMARCH_SOFTSHADOW
 #define FNC_RAYMARCH_SOFTSHADOW
 
-float raymarchSoftShadow( float3 ro, float3 rd, in float mint, in float maxt, float w ) {
+float raymarchSoftShadow(float3 ro, float3 rd) {
+    const float mint = RAYMARCH_SHADOW_MIN_DIST;
+    const float maxt = RAYMARCH_SHADOW_MAX_DIST;
+    const float w = RAYMARCH_SHADOW_SOLID_ANGLE;
+
     float res = 1.0;
     float t = mint;
     for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
@@ -38,15 +44,13 @@ float raymarchSoftShadow( float3 ro, float3 rd, in float mint, in float maxt, fl
             break;
         float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
-        t += clamp(h, 0.005, 0.50);
+
+        t += clamp(h, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST);
         if (res < -1.0 || t > maxt)
             break;
     }
     res = max(res, -1.0);
     return 0.25 * (1.0 + res) * (1.0 + res) * (2.0 - res);
 }
-
-float raymarchSoftShadow( float3 ro, float3 rd, in float tmin, in float tmax) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST, RAYMARCH_SHADOW_SOLID_ANGLE); }
-float raymarchSoftShadow( float3 ro, float3 rd) { return raymarchSoftShadow(ro, rd, RAYMARCH_SHADOW_MIN_DIST, RAYMARCH_SHADOW_MAX_DIST); }
 
 #endif

--- a/lighting/raymarch/softShadow.hlsl
+++ b/lighting/raymarch/softShadow.hlsl
@@ -33,8 +33,9 @@ options:
 float raymarchSoftShadow( float3 ro, float3 rd, in float mint, in float maxt, float w ) {
     float res = 1.0;
     float t = mint;
-    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS && t < maxt; i++)
-    {
+    for (int i = 0; i < RAYMARCHSOFTSHADOW_ITERATIONS; i++) {
+        if (t >= maxt)
+            break;
         float h = RAYMARCH_MAP_FNC(ro + t * rd).sdf;
         res = min(res, h / (w * t));
         t += clamp(h, 0.005, 0.50);


### PR DESCRIPTION
On a quest to remove all magic numbers from the raymarching code and expose them as meaningful parameters whenever possible:
* Exposed offset param in `normal`
* Exposed all magic number in `ao` as params
* Refactored `softShadow`params.
