### PR TITLE
Tweaks and clips to make things work on ThreeJS

### DIFF
--- a/color/luminance.glsl
+++ b/color/luminance.glsl
@@ -1,6 +1,8 @@
 /*
 contributor: nan
-description: Computes the luminance of the specified linear RGB color using the luminance coefficients from Rec. 709.
+description: |
+    Computes the luminance of the specified linear RGB color using the luminance coefficients from Rec. 709.
+    Note, ThreeJS seems to inject this in all their shaders. Which could lead to issues
 use: luminance(<vec3|vec4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
@@ -9,6 +11,6 @@ license:
 
 #ifndef FNC_LUMINANCE 
 #define FNC_LUMINANCE
-float luminance(vec3 v) { return dot(v, vec3(0.21250175, 0.71537574, 0.07212251)); }
-float luminance(vec4 v) { return luminance( v.rgb ); }
+float luminance(in vec3 linear) { return dot(linear, vec3(0.21250175, 0.71537574, 0.07212251)); }
+float luminance(in vec4 linear) { return luminance( linear.rgb ); }
 #endif

--- a/color/luminance.glsl
+++ b/color/luminance.glsl
@@ -7,8 +7,8 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
-#ifndef FNC_LUMINANCE
+#ifndef FNC_LUMINANCE 
 #define FNC_LUMINANCE
-float luminance(in vec3 linear) { return dot(linear, vec3(0.21250175, 0.71537574, 0.07212251)); }
-float luminance(in vec4 linear) { return luminance( linear.rgb ); }
+float luminance(vec3 v) { return dot(v, vec3(0.21250175, 0.71537574, 0.07212251)); }
+float luminance(vec4 v) { return luminance( v.rgb ); }
 #endif

--- a/color/luminance.glsl
+++ b/color/luminance.glsl
@@ -9,7 +9,7 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
 
-#ifndef FNC_LUMINANCE 
+#ifndef FNC_LUMINANCE
 #define FNC_LUMINANCE
 float luminance(in vec3 linear) { return dot(linear, vec3(0.21250175, 0.71537574, 0.07212251)); }
 float luminance(in vec4 linear) { return luminance( linear.rgb ); }

--- a/color/tonemap/debug.glsl
+++ b/color/tonemap/debug.glsl
@@ -1,5 +1,3 @@
-#include "../luminance.glsl"
-
 /*
 contributors: nan
 description: |
@@ -58,7 +56,8 @@ vec3 tonemapDebug(const vec3 x) {
 
     // The 5th color in the array (cyan) represents middle gray (18%)
     // Every stop above or below middle gray causes a color shift
-    float v = log2(luminance(x) / 0.18);
+    float l = dot(x, vec3(0.21250175, 0.71537574, 0.07212251));
+    float v = log2(l / 0.18);
     v = clamp(v + 5.0, 0.0, 15.0);
     int index = int(v);
     return mix(debugColors[index], debugColors[index + 1], v - float(index));

--- a/color/tonemap/filmic.glsl
+++ b/color/tonemap/filmic.glsl
@@ -1,7 +1,3 @@
-
-
-#include "../luminance.glsl"
-
 /*
 contributors: [Jim Hejl, Richard Burgess-Dawson ]
 description: Haarm-Peter Duikers curve from John Hables presentation "Uncharted 2 HDR Lighting", Page 140, http://www.gdcvault.com/play/1012459/Uncharted_2__HDR_Lighting

--- a/color/tonemap/reinhard.glsl
+++ b/color/tonemap/reinhard.glsl
@@ -1,5 +1,3 @@
-#include "../luminance.glsl"
-
 /*
 contributors: [Erik Reinhard, Michael Stark, Peter Shirley, James Ferwerda]
 description: Photographic Tone Reproduction for Digital Images. http://www.cmap.polytechnique.fr/~peyre/cours/x2005signal/hdr_photographic.pdf
@@ -8,6 +6,6 @@ use: <vec3|vec4> tonemapReinhard(<vec3|vec4> x)
 
 #ifndef FNC_TONEMAPREINHARD
 #define FNC_TONEMAPREINHARD
-vec3 tonemapReinhard(const vec3 v) { return v / (1.0 + luminance(v)); }
+vec3 tonemapReinhard(const vec3 v) { return v / (1.0 + dot(v, vec3(0.21250175, 0.71537574, 0.07212251))); }
 vec4 tonemapReinhard(const vec4 v) { return vec4( tonemapReinhard(v.rgb), v.a ); }
 #endif

--- a/color/tonemap/reinhardJodie.glsl
+++ b/color/tonemap/reinhardJodie.glsl
@@ -1,6 +1,3 @@
-
-#include "../luminance.glsl"
-
 /*
 contributors: [Erik Reinhard, Michael Stark, Peter Shirley, James Ferwerda]
 description: Photographic Tone Reproduction for Digital Images. http://www.cmap.polytechnique.fr/~peyre/cours/x2005signal/hdr_photographic.pdf
@@ -10,7 +7,7 @@ use: <vec3|vec4> tonemapReinhardJodie(<vec3|vec4> x)
 #ifndef FNC_TONEMAPREINHARDJODIE
 #define FNC_TONEMAPREINHARDJODIE
 vec3 tonemapReinhardJodie(const vec3 x) { 
-    float l = luminance(x);
+    float l = dot(x, vec3(0.21250175, 0.71537574, 0.07212251));
     vec3 tc = x / (x + 1.0);
     return mix(x / (l + 1.0), tc, tc); 
 }

--- a/lighting/envMap.glsl
+++ b/lighting/envMap.glsl
@@ -30,7 +30,7 @@ license:
 #endif
 #endif
 
-#if __VERSION__ < 430
+#if !defined(ENVMAP_MAX_MIP_LEVEL) && __VERSION__ < 430
 #define ENVMAP_MAX_MIP_LEVEL 3.0
 #endif
 

--- a/lighting/light/iblEvaluate.glsl
+++ b/lighting/light/iblEvaluate.glsl
@@ -28,7 +28,7 @@ void lightIBLEvaluate(Material mat, inout ShadingData shadingData) {
     vec3 specularColorE = shadingData.specularColor * E.x + E.y;
 #endif
 
-vec3 energyCompensation = vec3(1.0, 1.0, 1.0);
+    vec3 energyCompensation = vec3(1.0, 1.0, 1.0);
 
 #if defined(IBL_IMPORTANCE_SAMPLING) &&  __VERSION__ >= 130
     vec3 Fr = specularImportanceSampling(shadingData.linearRoughness, shadingData.specularColor,
@@ -44,15 +44,13 @@ vec3 energyCompensation = vec3(1.0, 1.0, 1.0);
     Fr  += fresnelReflection(mat, shadingData);
 #endif
 
+vec3 Fd = shadingData.diffuseColor;
 #if defined(SCENE_SH_ARRAY)
-    vec3 Fd = shadingData.diffuseColor * (1.0-specularColorE);
-    Fd  *= tonemap( sphericalHarmonics(shadingData.N) );
-#elif defined(IBL_IMPORTANCE_SAMPLING)
-    vec3 Fd = shadingData.diffuseColor;
-    Fd *= envMap(shadingData.N, 1.0);
-#else
-    vec3 Fd = shadingData.diffuseColor * (1.0-specularColorE);
-    Fd *= envMap(shadingData.N, 1.0);
+    Fd *= sphericalHarmonics(shadingData.N) * (1.0-specularColorE);
+// #elif defined(IBL_IMPORTANCE_SAMPLING)
+//     Fd *= envMap(shadingData.N, 1.0);
+// #else
+//     Fd *= envMap(shadingData.N, 1.0) * (1.0-specularColorE);
 #endif
 
     // AO

--- a/lighting/light/iblEvaluate.glsl
+++ b/lighting/light/iblEvaluate.glsl
@@ -46,11 +46,17 @@ void lightIBLEvaluate(Material mat, inout ShadingData shadingData) {
 
 vec3 Fd = shadingData.diffuseColor;
 #if defined(SCENE_SH_ARRAY)
-    Fd *= sphericalHarmonics(shadingData.N) * (1.0-specularColorE);
-// #elif defined(IBL_IMPORTANCE_SAMPLING)
-//     Fd *= envMap(shadingData.N, 1.0);
-// #else
-//     Fd *= envMap(shadingData.N, 1.0) * (1.0-specularColorE);
+    #ifdef GLSLVIEWER
+    Fd *= tonemap(sphericalHarmonics(shadingData.N));
+    #else
+    Fd *= (sphericalHarmonics(shadingData.N));
+    #endif
+#else
+    Fd *= envMap(shadingData.N, 1.0);
+#endif
+
+#if !defined(IBL_IMPORTANCE_SAMPLING)
+    Fd *= (1.0-specularColorE);
 #endif
 
     // AO

--- a/lighting/pbrLittle.glsl
+++ b/lighting/pbrLittle.glsl
@@ -84,9 +84,9 @@ vec4 pbrLittle(Material mat, ShadingData shadingData) {
     vec3 ambientSpecular = tonemap( envMap(mat, shadingData) ) * specIntensity;
     ambientSpecular += fresnelReflection(mat, shadingData) * (1.0-mat.roughness);
 
-    albedo = albedo.rgb * notMetal + ( ambientSpecular 
-                    + LIGHT_COLOR * 2.0 * spec
-                    ) * (notMetal * smoothness + albedo * mat.metallic);
+    albedo =    albedo.rgb * notMetal + ( ambientSpecular 
+                + LIGHT_COLOR * 2.0 * spec
+                ) * (notMetal * smoothness + albedo * mat.metallic);
 
     return vec4(albedo, mat.albedo.a);
 }

--- a/lighting/specular/importanceSampling.glsl
+++ b/lighting/specular/importanceSampling.glsl
@@ -18,9 +18,8 @@ license: MIT License (MIT) Copyright (c) 2024 Shadi EL Hajj
 #define IBL_IMPORTANCE_SAMPLING_SAMPLES  16
 #endif
 
-#if !defined(FNC_SPECULAR_IMPORTANCE_SAMPLING) &&  __VERSION__ >= 130
+#if !defined(FNC_SPECULAR_IMPORTANCE_SAMPLING) && defined(SCENE_CUBEMAP) &&  __VERSION__ >= 130 
 #define FNC_SPECULAR_IMPORTANCE_SAMPLING
-
 
 vec3 specularImportanceSampling(float roughness, vec3 f0, vec3 p, vec3 n, vec3 v, vec3 r, float NoV, out vec3 energyCompensation) {
     const int numSamples = IBL_IMPORTANCE_SAMPLING_SAMPLES;
@@ -29,7 +28,7 @@ vec3 specularImportanceSampling(float roughness, vec3 f0, vec3 p, vec3 n, vec3 v
     mat3 T = tbn(n, up);
     // T *= rotate3dZ(TWO_PI * random(p));
 
-    int width = textureSize(SCENE_CUBEMAP, 0).x;
+    float width = float(textureSize(SCENE_CUBEMAP, 0).x);
     float omegaP = (4.0 * PI) / (6.0 * width * width);
 
     vec3 indirectSpecular = vec3(0.0, 0.0, 0.0);

--- a/math/hammersley.glsl
+++ b/math/hammersley.glsl
@@ -18,7 +18,7 @@ vec2 hammersley(uint index, int numSamples) {
     bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
     bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
     bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
-    return vec2(float(index) / numSamples, float(bits) * tof);
+    return vec2(float(index) / float(numSamples), float(bits) * tof);
 }
 
 vec3 hemisphereCosSample(vec2 u) {

--- a/space/lookAt.glsl
+++ b/space/lookAt.glsl
@@ -5,8 +5,10 @@ use:
     - <mat3> lookAt(<vec3> forward, <vec3> up)
     - <mat3> lookAt(<vec3> eye, <vec3> target, <vec3> up)
     - <mat3> lookAt(<vec3> eye, <vec3> target, <float> roll)
+    - <mat3> lookAt(<vec3> forward)
 options:
     - LOOK_AT_LEFT_HANDED: assume a left-handed coordinate system
+    - LOOK_AT_RIGHT_HANDED: assume a right-handed coordinate system
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -16,13 +18,13 @@ license:
 #define FNC_LOOKAT
 
 mat3 lookAt(vec3 forward, vec3 up) {
-    vec3 zaxis = forward;
-#if defined(LOOK_AT_LEFT_HANDED)
-    vec3 xaxis = normalize(cross(up, zaxis));
-    vec3 yaxis = normalize(cross(zaxis, xaxis));
-#else
+    vec3 zaxis = normalize(forward);
+#if defined(LOOK_AT_RIGHT_HANDED)
     vec3 xaxis = normalize(cross(zaxis, up));
-    vec3 yaxis = normalize(cross(xaxis, zaxis));
+    vec3 yaxis = cross(xaxis, zaxis);
+#else
+    vec3 xaxis = normalize(cross(up, zaxis));
+    vec3 yaxis = cross(zaxis, xaxis);
 #endif
     return mat3(xaxis, yaxis, zaxis);
 }

--- a/space/lookAt.glsl
+++ b/space/lookAt.glsl
@@ -1,12 +1,12 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: create a look at matrix
+description: create a look at matrix. Right handed by default.
 use:
     - <mat3> lookAt(<vec3> forward, <vec3> up)
     - <mat3> lookAt(<vec3> eye, <vec3> target, <vec3> up)
     - <mat3> lookAt(<vec3> eye, <vec3> target, <float> roll)
 options:
-    - LOOK_AT_RIGHT_HANDED: assume right-handed coordinate system. Default is Left-handed.
+    - LOOK_AT_LEFT_HANDED: assume a left-handed coordinate system
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -17,12 +17,12 @@ license:
 
 mat3 lookAt(vec3 forward, vec3 up) {
     vec3 zaxis = forward;
-#if defined (LOOK_AT_RIGHT_HANDED)
-    vec3 xaxis = normalize(cross(zaxis, up));
-    vec3 yaxis = normalize(cross(xaxis, zaxis));
-#else
+#if defined(LOOK_AT_LEFT_HANDED)
     vec3 xaxis = normalize(cross(up, zaxis));
     vec3 yaxis = normalize(cross(zaxis, xaxis));
+#else
+    vec3 xaxis = normalize(cross(zaxis, up));
+    vec3 yaxis = normalize(cross(xaxis, zaxis));
 #endif
     return mat3(xaxis, yaxis, zaxis);
 }

--- a/space/lookAt.hlsl
+++ b/space/lookAt.hlsl
@@ -5,6 +5,10 @@ use:
     - <float3x3> lookAt(<float3> forward, <float3> up)
     - <float3x3> lookAt(<float3> target, <float3> eye, <float3> up)
     - <float3x3> lookAt(<float3> target, <float3> eye, <float> roll)
+    - <float3x3> lookAt(<float3> forward)
+options:
+    - LOOK_AT_LEFT_HANDED: assume a left-handed coordinate system
+    - LOOK_AT_RIGHT_HANDED: assume a right-handed coordinate system
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -13,15 +17,14 @@ license:
 #ifndef FNC_LOOKAT
 #define FNC_LOOKAT
 
-float3x3 lookAt(float3 forward, float3 up)
-{
-    float3 zaxis = forward;
+float3x3 lookAt(float3 forward, float3 up) {
+    float3 zaxis = normalize(forward);
 #if defined (LOOK_AT_RIGHT_HANDED)
     float3 xaxis = normalize(cross(zaxis, up));
-    float3 yaxis = normalize(cross(xaxis, zaxis));
+    float3 yaxis = cross(xaxis, zaxis);
 #else
     float3 xaxis = normalize(cross(up, zaxis));
-    float3 yaxis = normalize(cross(zaxis, xaxis));
+    float3 yaxis = cross(zaxis, xaxis);
 #endif
     float3x3 m;
     m._m00_m10_m20 = xaxis;
@@ -30,20 +33,17 @@ float3x3 lookAt(float3 forward, float3 up)
     return m;
 }
 
-float3x3 lookAt(float3 eye, float3 target, float3 up)
-{
+float3x3 lookAt(float3 eye, float3 target, float3 up) {
     float3 forward = normalize(target - eye);
     return lookAt(forward, up);
 }
 
-float3x3 lookAt(float3 eye, float3 target, float roll)
-{
+float3x3 lookAt(float3 eye, float3 target, float roll) {
     float3 up = float3(sin(roll), cos(roll), 0.0);
     return lookAt(eye, target, up);
 }
 
-float3x3 lookAt(float3 forward)
-{
+float3x3 lookAt(float3 forward) {
     return lookAt(forward, float3(0.0, 1.0, 0.0));
 }
 

--- a/space/lookAt.msl
+++ b/space/lookAt.msl
@@ -5,6 +5,10 @@ use:
     - <mat3> lookAt(<float3> forward, <float3> up)
     - <mat3> lookAt(<float3> eye, <float3> target, <float3> up)
     - <mat3> lookAt(<float3> eye, <float3> target, <float> rolle)
+    - <mat3> lookAt(<float3> forward)
+options:
+    - LOOK_AT_LEFT_HANDED: assume a left-handed coordinate system
+    - LOOK_AT_RIGHT_HANDED: assume a right-handed coordinate system
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -14,9 +18,14 @@ license:
 #define FNC_LOOKAT
 
 mat3 lookAt(float3 forward, float3 up) {
-    float3 xaxis = normalize(cross(forward, up));
-    float3 yaxis = up;
-    float3 zaxis = forward;
+    float3 zaxis = normalize(forward);
+#if defined(LOOK_AT_RIGHT_HANDED)
+    float3 xaxis = normalize(cross(zaxis, up));
+    float3 yaxis = cross(xaxis, zaxis);
+#else
+    float3 xaxis = normalize(cross(up, zaxis));
+    float3 yaxis = cross(zaxis, xaxis);
+#endif
     return mat3(xaxis, yaxis, zaxis);
 }
 


### PR DESCRIPTION
Took some minor work to make this work correctly on ThreeJS. Mayor changes are:

* ThreeJS inject a `float luminance(vec3)` function. Unfortunately they don't use any kind of define flag for it that we could use to single it out and prevent the collision. I should touch bases with @mrdoob and other ThreeJS maintainers to have a more robust solution for the future. For the moment I'm removing the dependency to that function just because is a one-liner.

* I'm making look-at matrices right handed by default in OpenGL (GLSL). In the same way we have `LOOK_AT_RIGHT_HANDED` now we have `LOOK_AT_LEFT_HANDED` to change the default behavior. This is mostly after a quick google that confirms that right handed view matrices are default on OpenGL. So, I could be totally wrong and misguided.

* fix the previous `tonemap()` additions to the SH sampling to make it active just for `#ifdef GLSLVIEWER`. This is temporal, in the longer run I just need to fix the way I'm computing the SH. But now more correct, just like @shadielhajj. 

* the rest are smaller things that were surface when trying to make the new PBR pipeline work on WebGL 2.0

Here running in this double ThreeJS/GlslViewer example: 

https://github.com/user-attachments/assets/44c03bd4-90f1-4b5e-9e8b-bb36e6e984f5