### PR TITLE
Update cart2polar.glsl

### DIFF
--- a/space/cart2polar.glsl
+++ b/space/cart2polar.glsl
@@ -11,6 +11,16 @@ vec2 cart2polar(in vec2 st) {
     return vec2(atan(st.y, st.x), length(st));
 }
 
+/*
+Add by jane00
+Refer to https://en.wikipedia.org/wiki/Spherical_coordinate_system , there are two different definition for phi and theta, which are opposite to each other.
+
+Before the changes by shadielhajj committed on 2024 Jul 26,  The physics convention(ISO convention) is followed, phi means "azimuthal angle", theta for "polar angle"
+but now, The "mathematics convention" is followed, phi means "polar angle", theta for "azimuthal angle"
+
+So be careful with the old code !!!
+*/
+
 // https://mathworld.wolfram.com/SphericalCoordinates.html
 vec3 cart2polar( in vec3 st ) {
     float r = length(st);


### PR DESCRIPTION
Add description for convention changed.

Add by jane00
Refer to https://en.wikipedia.org/wiki/Spherical_coordinate_system , there are two different definition for phi and theta, which are opposite to each other.

Before the changes by shadielhajj committed on 2024 Jul 26,  The physics convention(ISO convention) is followed, phi means "azimuthal angle", theta for "polar angle"
but now, The "mathematics convention" is followed, phi means "polar angle", theta for "azimuthal angle"

So be careful with the old code !!!