### PR TITLE
Option to take the absolute value of the SDF distance.

### DIFF
--- a/lighting/raymarch/cast.glsl
+++ b/lighting/raymarch/cast.glsl
@@ -35,7 +35,12 @@ Material raymarchCast( in vec3 ro, in vec3 rd ) {
     m.valid = false;
     for (int i = 0; i < RAYMARCH_SAMPLES; i++) {
         Material res = RAYMARCH_MAP_FNC(ro + rd * t);
-        if (res.sdf < RAYMARCH_MIN_HIT_DIST || t > tmax) 
+#ifdef RAYMARCH_ABS_DIST
+        float dist = abs(res.sdf);
+#else
+        float dist = res.sdf;
+#endif
+        if (dist < RAYMARCH_MIN_HIT_DIST || t > tmax) 
             break;
         m = res;
         t += res.sdf;

--- a/lighting/raymarch/cast.hlsl
+++ b/lighting/raymarch/cast.hlsl
@@ -35,8 +35,12 @@ Material raymarchCast( in float3 ro, in float3 rd ) {
     m.valid = false;
     for (int i = 0; i < RAYMARCH_SAMPLES; i++) {
         Material res = RAYMARCH_MAP_FNC(ro + rd * t);
-        if (res.sdf < RAYMARCH_MIN_HIT_DIST || t > tmax) 
-            break;
+#ifdef RAYMARCH_ABS_DIST
+        float dist = abs(res.sdf);
+#else
+        float dist = res.sdf;
+#endif
+        if (dist < RAYMARCH_MIN_HIT_DIST || t > tmax) break;
         m = res;
         t += res.sdf;
     }


### PR DESCRIPTION
As noted by IQ in his article [FBM detail in SDFs - 2019](https://iquilezles.org/articles/fbmsdf/)

> The problem with tradicional noise/fBM displacements on SDFs is this: the (regular, arithmetic) addition of two SDFs is not an SDF. Furthermore, the addition of an SDF and some other field/function (SDF or not) is also not an SDF (except for very carefully manufactured functions, that is). So, when adding a regular fBM, sine wave or any other displacement function to a "host" SDF, we don't get a valid SDF anymore (we violate the principle that the gradient of an SDF must have length 1.0).
That of course doesn't stop us from still trying, and we often do add arbitrary functions to our SDFs in the hopes of changing their shape. Sometimes we can achieve some level of success when done gently, but it all breaks rapidly when we push it a little bit.

It's always tempting to use procedural functions such as FBMs in lieu of SDFs. And it works. Somehow. We often get raymarching artefacts in areas of high frequency detail such as is. The artifacts are even more jarring when the camera is moving since they tend to flicker and glitch.
<img width="528" alt="Screenshot 2025-02-04 155348" src="https://github.com/user-attachments/assets/ce879dcb-e830-4af6-8835-2787bde13d7c" />

The issue can be mitigated by taking the absolute value of the SDF when comparing to the minimum hit distance. It's quick, it's easy and it works surprisingly well.
![Screenshot 2025-02-04 155329](https://github.com/user-attachments/assets/f060de1e-b4e3-48c2-a477-a8b502de6cb8)

The PR adds an extra `RAYMARCH_ABS_DIST` switch which does exactly that. It's off by default, since raymarching is a bit slower using this method.

This [thread](https://gamedev.stackexchange.com/questions/168462/raymarching-signed-distance-function-resulting-in-holes-on-surface-step-size-r) explains with a bit more detail why this actually works.
