### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The functions are divided into different categories:
 ### How is it [designed](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md)?
 
 LYGIA is designed to be very granular (each file holds one function), multi-language (each language has its own file extension) and flexible. Flexible how?
-There are some functions whose behavior can be changed using the `#define` keyword before including them. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword, as follows:
+There are some functions whose behavior can be changed using the `#define` keyword before including them. For example, [gaussian blurs](filter/gaussianBlur) are usually done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword, as follows:
 
 ```glsl
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # LYGIA Shader Library 
 
-LYGIA is the biggest shader library. Battle proof, cross platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient. Support multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all mayor environments, engines and frameworks.
+LYGIA is the biggest shader library. Battle proof, cross platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient. Support multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all major environments, engines and frameworks.
 
 Best of all, LYGIA grows and improves every day thanks to the support of the community. Become a [Contributor](https://github.com/patriciogonzalezvivo/lygia) or a [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/patriciogonzalezvivo)
 
@@ -108,7 +108,7 @@ If you are concerned about the size of the library you might also be interested 
     python prune.py --all --keep glsl
 ```
 
-Alternatively, if your are working on a `npm` project, there is a [npm bundle](https://www.npmjs.com/package/lygia) you could use.
+Alternatively, if you are working on a `npm` project, there is a [npm bundle](https://www.npmjs.com/package/lygia) you could use.
 
 If you are working on web project you may want to resolve the dependencies using a bundler like [vite glsl plugin (local bundle)](https://github.com/UstymUkhman/vite-plugin-glsl), [esbuild glsl plugin (local bundle)](https://github.com/ricardomatias/esbuild-plugin-glsl-include) or [webpack glsl plugin (local bundle)](https://github.com/grieve/webpack-glsl-loader).
 
@@ -177,7 +177,7 @@ The functions are divided into different categories:
 ### How is it [designed](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md)?
 
 LYGIA is designed to be very granular (each file holds one function), multilanguage (each language has its own file extension) and flexible. Flexible how?
-There are some functions whose behavior can be changed using the `#defines` keyword before including it. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually are done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword this way:
+There are some functions whose behavior can be changed using the `#defines` keyword before including it. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword this way:
 
 ```glsl
 
@@ -211,7 +211,7 @@ Learn more about [LYGIAS design principles in the DESIGN.md file](https://github
 LYGIA has a long way to go and welcomes all kinds of contributions. You can help by:
 
 * **Bug fixing**
-* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc) is a big part of the challenge. Not all language are the same and we want to make sure make sure each function is optimized and carefully crafted for each environment. This means, the more eyes looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
+* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc) is a big part of the challenge. Not all language are the same and we want to make sure each function is optimized and carefully crafted for each environment. This means, the more eyes looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
 * **New functions or improving the current implementations**. Please take a look to the [Contributing Guidelines](https://github.com/patriciogonzalezvivo/lygia/blob/main/CONTRIBUTING.md) before starting.
 * **Documentation**. Each function has a header with some information describing the function. Make sure to fill this information when adding a new function.
 * Adding new **examples** and integrations for new environments like: [Godot](https://godotengine.org/), [ISF](https://isf.video/), [MaxMSP](https://cycling74.com/products/max), etc.
@@ -219,7 +219,7 @@ LYGIA has a long way to go and welcomes all kinds of contributions. You can help
 
 Collaborators and sponsors are automatically added to the [commercial license](https://lygia.xyz/license). Making a PR or subscribing to the github sponsors program is the shortest path to get access to the commercial license. It's all automated, not red taping. LYGIA belongs to those that takes care of it.
 
-## License 
+## License
 
 LYGIA belongs to those that support it. For that it uses a dual-licensed under the [Prosperity License](https://prosperitylicense.com/versions/3.0.0) and the [Patron License](https://lygia.xyz/license) for [sponsors](https://github.com/sponsors/patriciogonzalezvivo) and [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors).
 
@@ -227,7 +227,7 @@ LYGIA belongs to those that support it. For that it uses a dual-licensed under t
 
 It's also possible to get a permanent commercial license hooked to a single and specific version of LYGIA.
 
-If you have doubts please reaching out to patriciogonzalezvivo at gmail dot com
+If you have doubts please reach out to patriciogonzalezvivo at gmail dot com
 
 ## Credits
 
@@ -236,6 +236,3 @@ Created and maintained by [Patricio Gonzalez Vivo](https://patriciogonzalezvivo.
 This library has been built in many cases on top of the work of brilliant and generous people like: [Inigo Quiles](https://www.iquilezles.org/), [Morgan McGuire](https://casual-effects.com/), [Alan Wolfe](https://blog.demofox.org/), [Matt DesLauriers](https://www.mattdesl.com/), [Bjorn Ottosson](https://github.com/bottosson), [Hugh Kennedy](https://github.com/hughsk), and many others.
 
 Also is being constantly maintain, translated and/or extended by generous contributors like: [Shadi El Hajj](https://github.com/shadielhajj), [Kathy](https://github.com/kfahn22), [Bonsak Schiledrop](https://github.com/bonsak), [Amin Shazrin](https://github.com/ammein), [Guido Schmidt](https://github.com/guidoschmidt), and many others.
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <img src="https://lygia.xyz/imgs/lygia.svg" alt="LYGIA" width="200" style="display: block; margin-left: auto; margin-right: auto; filter: drop-shadow(2px 3px 4px gray);">
 
-# LYGIA Shader Library 
+# LYGIA Shader Library
 
-LYGIA is the biggest shader library. Battle proof, cross platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient. Support multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all major environments, engines and frameworks.
+LYGIA is the biggest shader library. Battle proof, cross-platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient, supports multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all major environments, engines and frameworks.
 
-Best of all, LYGIA grows and improves every day thanks to the support of the community. Become a [Contributor](https://github.com/patriciogonzalezvivo/lygia) or a [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/patriciogonzalezvivo)
+Best of all, LYGIA grows and improves every day thanks to the support of the community. Become a [Contributor](https://github.com/patriciogonzalezvivo/lygia) or a [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/patriciogonzalezvivo).
 
 ## How to use it?
 
-In your shader just `#include` the functions you need and then use them:
+In your shader just `#include` the functions you need and use them:
 
 <div class="codeAndCanvas" data="example.frag">
 
@@ -80,11 +80,11 @@ LYGIA have been integrated into the following Engines, Frameworks, Creative Tool
     <a href="https://dev.shader.app/"><img src="https://dev.shaders.app/apple-touch-icon.png" alt="shaderApp" title="shaderApp" width="64"/></a>
 </p>
 
-If you are working on a project and want to use LYGIA, you have two options: cloning a **local** version that then you can bundle into your project; or using the **server** ( https://lygia.xyz ) to resolve the dependencies online. How each one works?
+If you are working on a project and want to use LYGIA, you have two options: cloning a **local** version that you can bundle into your project; or using the **server** ( https://lygia.xyz ) to resolve the dependencies online.
 
 ### LYGIA Locally
 
-If you want to work **locally**, you must ensure that your environment can resolve `#include` dependencies. You can find some examples in [here specially for GLSL](https://github.com/patriciogonzalezvivo/lygia/blob/main/README_GLSL.md). Then you just need to clone LYGIA into your project relative to the shader you are loading:
+If you want to work **locally**, you must ensure that your environment can resolve `#include` dependencies. You can find some examples in [here specifically for GLSL](https://github.com/patriciogonzalezvivo/lygia/blob/main/README_GLSL.md). Then you just need to clone LYGIA into your project relative to the shader you are loading:
 
 ```bash
     git clone https://github.com/patriciogonzalezvivo/lygia.git
@@ -110,24 +110,23 @@ If you are concerned about the size of the library you might also be interested 
 
 Alternatively, if you are working on a `npm` project, there is a [npm bundle](https://www.npmjs.com/package/lygia) you could use.
 
-If you are working on web project you may want to resolve the dependencies using a bundler like [vite glsl plugin (local bundle)](https://github.com/UstymUkhman/vite-plugin-glsl), [esbuild glsl plugin (local bundle)](https://github.com/ricardomatias/esbuild-plugin-glsl-include) or [webpack glsl plugin (local bundle)](https://github.com/grieve/webpack-glsl-loader).
-
+If you are working on a web project you may want to resolve the dependencies using a bundler like [vite glsl plugin (local bundle)](https://github.com/UstymUkhman/vite-plugin-glsl), [esbuild glsl plugin (local bundle)](https://github.com/ricardomatias/esbuild-plugin-glsl-include) or [webpack glsl plugin (local bundle)](https://github.com/grieve/webpack-glsl-loader).
 
 ### LYGIA server
 
-If you are working on a **cloud platform** (like [CodePen](https://codepen.io/) or [Observable](https://observablehq.com/@radames/hello-lygia-shader-library) ) you probably want to resolve the dependencies without needing to install anything. For that just add a link to `https://lygia.xyz/resolve.js` (JS) or `https://lygia.xyz/resolve.esm.js` (ES6 module): 
+If you are working on a **cloud platform** (like [CodePen](https://codepen.io/) or [Observable](https://observablehq.com/@radames/hello-lygia-shader-library)) you probably want to resolve the dependencies without needing to install anything. For that just add a link to `https://lygia.xyz/resolve.js` (JS) or `https://lygia.xyz/resolve.esm.js` (ES6 module):
 
 ```html
-    <!-- as a JavaScript source -->
+    <!-- As JavaScript source -->
     <script src="https://lygia.xyz/resolve.js"></script>
 
-    <!-- Or as a ES6 module -->
+    <!-- Or as an ES6 module -->
     <script type="module">
         import resolveLygia from "https://lygia.xyz/resolve.esm.js"
     </script>
 ```
 
-To then resolve the dependencies by passing a `string` or `strings[]` to `resolveLygia()` or `resolveLygiaAsync()`:
+Then you can resolve the dependencies by passing a `string` or `strings[]` to `resolveLygia()` or `resolveLygiaAsync()`:
 
 ```js
     // 1. FIRST
@@ -138,7 +137,7 @@ To then resolve the dependencies by passing a `string` or `strings[]` to `resolv
 
     // OR.
     
-    // ASync resolver, all includes in parallel calls
+    // Async resolver, all includes in parallel calls
     vertSource = resolveLygiaAsync(vertSource);
     fragSource = resolveLygiaAsync(fragSource);
     
@@ -165,7 +164,7 @@ The functions are divided into different categories:
 * [`animation/`](https://lygia.xyz/animation): animation operations: easing
 * [`generative/`](https://lygia.xyz/generative): generative functions: `random()`, `noise()`, etc. 
 * [`sdf/`](https://lygia.xyz/sdf): signed distance field functions.
-* [`draw/`](https://lygia.xyz/draw): drawing functions like `digits()`, `stroke()`, `fill`, etc/.
+* [`draw/`](https://lygia.xyz/draw): drawing functions like `digits()`, `stroke()`, `fill`, etc.
 * [`sample/`](https://lygia.xyz/sample): sample operations
 * [`filter/`](https://lygia.xyz/filter): typical filter operations: different kind of blurs, mean and median filters.
 * [`distort/`](https://lygia.xyz/distort): distort sampling operations
@@ -173,11 +172,10 @@ The functions are divided into different categories:
 * [`geometry/`](https://lygia.xyz/geometry): operation related to geometries: intersections and AABB accelerating structures.
 * [`morphological/`](https://lygia.xyz/morphological): morphological filters: dilation, erosion, alpha and poisson fill.
 
-
 ### How is it [designed](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md)?
 
-LYGIA is designed to be very granular (each file holds one function), multilanguage (each language has its own file extension) and flexible. Flexible how?
-There are some functions whose behavior can be changed using the `#defines` keyword before including it. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword this way:
+LYGIA is designed to be very granular (each file holds one function), multi-language (each language has its own file extension) and flexible. Flexible how?
+There are some functions whose behavior can be changed using the `#define` keyword before including them. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword, as follows:
 
 ```glsl
 
@@ -204,24 +202,24 @@ In the same way you can change the sampling function that the gaussian uses. Ex:
 #define GAUSSIANBLUR_SAMPLER_FNC(TEX, UV) sampleClamp2edge(TEX, UV)
 ```
 
-Learn more about [LYGIAS design principles in the DESIGN.md file](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md).
+Learn more about [LYGIA's design principles in the DESIGN.md file](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md).
 
 ## Contributions
 
 LYGIA has a long way to go and welcomes all kinds of contributions. You can help by:
 
 * **Bug fixing**
-* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc) is a big part of the challenge. Not all language are the same and we want to make sure each function is optimized and carefully crafted for each environment. This means, the more eyes looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
-* **New functions or improving the current implementations**. Please take a look to the [Contributing Guidelines](https://github.com/patriciogonzalezvivo/lygia/blob/main/CONTRIBUTING.md) before starting.
+* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc.) is a big part of the challenge. Not all languages are the same and we want to make sure each function is optimized and carefully crafted for each environment. This means, the more eyes are looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
+* **New functions or improving the current implementations**. Please take a look to the [Contribution Guidelines](https://github.com/patriciogonzalezvivo/lygia/blob/main/CONTRIBUTING.md) before starting.
 * **Documentation**. Each function has a header with some information describing the function. Make sure to fill this information when adding a new function.
 * Adding new **examples** and integrations for new environments like: [Godot](https://godotengine.org/), [ISF](https://isf.video/), [MaxMSP](https://cycling74.com/products/max), etc.
-* **Financial** [sponsorships](https://github.com/sponsors/patriciogonzalezvivo). Right now, the money that flows in is invested on the server and infraestructure. Long term plan will be to be able to pay lead contributors and maintainers.
+* **Financial** [sponsorships](https://github.com/sponsors/patriciogonzalezvivo). Right now, the money that flows in is invested on the server and infrastructure. Long term plan will be to be able to pay lead contributors and maintainers.
 
-Collaborators and sponsors are automatically added to the [commercial license](https://lygia.xyz/license). Making a PR or subscribing to the github sponsors program is the shortest path to get access to the commercial license. It's all automated, not red taping. LYGIA belongs to those that takes care of it.
+Collaborators and sponsors are automatically added to the [commercial license](https://lygia.xyz/license). Making a PR or subscribing to the GitHub sponsors program is the shortest path to get access to the commercial license. It's all automated, not red taping. LYGIA belongs to those that take care of it.
 
 ## License
 
-LYGIA belongs to those that support it. For that it uses a dual-licensed under the [Prosperity License](https://prosperitylicense.com/versions/3.0.0) and the [Patron License](https://lygia.xyz/license) for [sponsors](https://github.com/sponsors/patriciogonzalezvivo) and [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors).
+LYGIA belongs to those that support it. For that it is dual-licensed under the [Prosperity License](https://prosperitylicense.com/versions/3.0.0) and the [Patron License](https://lygia.xyz/license) for [sponsors](https://github.com/sponsors/patriciogonzalezvivo) and [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors).
 
 [Sponsors](https://github.com/sponsors/patriciogonzalezvivo) and [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors) are automatically added to the [Patron License](https://lygia.xyz/license) and they can ignore any non-commercial rule of the [Prosperity License](https://prosperitylicense.com/versions/3.0.0) software.
 
@@ -231,8 +229,8 @@ If you have doubts please reach out to patriciogonzalezvivo at gmail dot com
 
 ## Credits
 
-Created and maintained by [Patricio Gonzalez Vivo](https://patriciogonzalezvivo.com/)( <a rel="me" href="https://merveilles.town/@patricio">Mastodon</a> | [Twitter](https://twitter.com/patriciogv) | [Instagram](https://www.instagram.com/patriciogonzalezvivo/) | [GitHub](https://github.com/sponsors/patriciogonzalezvivo) ) and every direct or indirect [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors) to the GitHub.
+Created and maintained by [Patricio Gonzalez Vivo](https://patriciogonzalezvivo.com/) ( <a rel="me" href="https://merveilles.town/@patricio">Mastodon</a> | [Twitter](https://twitter.com/patriciogv) | [Instagram](https://www.instagram.com/patriciogonzalezvivo/) | [GitHub](https://github.com/sponsors/patriciogonzalezvivo) ) and every direct or indirect [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors) to the GitHub repository.
 
 This library has been built in many cases on top of the work of brilliant and generous people like: [Inigo Quiles](https://www.iquilezles.org/), [Morgan McGuire](https://casual-effects.com/), [Alan Wolfe](https://blog.demofox.org/), [Matt DesLauriers](https://www.mattdesl.com/), [Bjorn Ottosson](https://github.com/bottosson), [Hugh Kennedy](https://github.com/hughsk), and many others.
 
-Also is being constantly maintain, translated and/or extended by generous contributors like: [Shadi El Hajj](https://github.com/shadielhajj), [Kathy](https://github.com/kfahn22), [Bonsak Schiledrop](https://github.com/bonsak), [Amin Shazrin](https://github.com/ammein), [Guido Schmidt](https://github.com/guidoschmidt), and many others.
+It also is being constantly maintained, translated and/or extended by generous contributors like: [Shadi El Hajj](https://github.com/shadielhajj), [Kathy](https://github.com/kfahn22), [Bonsak Schiledrop](https://github.com/bonsak), [Amin Shazrin](https://github.com/ammein), [Guido Schmidt](https://github.com/guidoschmidt), and many others.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # LYGIA Shader Library 
 
-LYGIA is the biggest shader library. Battle proof, cross platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient. Support multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all mayor enviroments, engines and frameworks. 
+LYGIA is the biggest shader library. Battle proof, cross platform and multi-language. Is made of reusable functions that will let you prototype, port and ship projects in just few minutes. It's very granular, flexible and efficient. Support multiple shading languages and can easily be added to virtually any project. There are already integrations for almost all mayor environments, engines and frameworks.
 
 Best of all, LYGIA grows and improves every day thanks to the support of the community. Become a [Contributor](https://github.com/patriciogonzalezvivo/lygia) or a [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub)](https://github.com/sponsors/patriciogonzalezvivo)
 
@@ -65,7 +65,7 @@ LYGIA have been integrated into the following Engines, Frameworks, Creative Tool
 <p style="text-align: center;" >
     <a href="https://github.com/patriciogonzalezvivo/lygia_p5_examples"><img src="https://lygia.xyz/imgs/p5.png" alt="p5" title="processing" width="64" /></a>
     <a href="https://editor.p5js.org/patriciogonzalezvivo/sketches"><img src="https://lygia.xyz/imgs/p5js.png" alt="p5js" title="p5js" width="64" /></a>
-    <a href="https://github.com/patriciogonzalezvivo/lygia_of_examples"><img src="https://lygia.xyz/imgs/of.png" alt="openFrameworks" tittle="openframeworks" width="64" /></a>
+    <a href="https://github.com/patriciogonzalezvivo/lygia_of_examples"><img src="https://lygia.xyz/imgs/of.png" alt="openFrameworks" title="openframeworks" width="64" /></a>
     <a href="https://github.com/vectorsize/lygia-td"><img title="static-resolver by vectorsize" src="https://lygia.xyz/imgs/td.png" alt="touchDesigner" title="touchDesigner" width="64" /></a>
     <a href="https://github.com/patriciogonzalezvivo/comfyui_glslnodes"><img src="https://lygia.xyz/imgs/comfy.png" alt="comfyui" title="comfyUI" width="64" /></a>
     <a href="https://github.com/ossia/score-examples"><img src="https://lygia.xyz/imgs/ossia.png" alt="ossia" title="ossia" width="64" /></a>
@@ -169,14 +169,14 @@ The functions are divided into different categories:
 * [`sample/`](https://lygia.xyz/sample): sample operations
 * [`filter/`](https://lygia.xyz/filter): typical filter operations: different kind of blurs, mean and median filters.
 * [`distort/`](https://lygia.xyz/distort): distort sampling operations
-* [`lighting/`](https://lygia.xyz/lighting): different lighting models and functions for foward/deferred/raymarching rendering
+* [`lighting/`](https://lygia.xyz/lighting): different lighting models and functions for forward/deferred/raymarching rendering
 * [`geometry/`](https://lygia.xyz/geometry): operation related to geometries: intersections and AABB accelerating structures.
 * [`morphological/`](https://lygia.xyz/morphological): morphological filters: dilation, erosion, alpha and poisson fill.
 
 
 ### How is it [designed](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md)?
 
-LYGIA is designed to be very granular (each file holds one function), multilanguage (each language have it's onw file extension) and flexible. Flexible how?
+LYGIA is designed to be very granular (each file holds one function), multilanguage (each language has its own file extension) and flexible. Flexible how?
 There are some functions whose behavior can be changed using the `#defines` keyword before including it. For example, [gaussian blurs](filter/gaussianBlur.glsl) are usually are done in two passes. By default, these are performed on their 1D version, but if you are interested in using a 2D kernel, all in the same pass, you will need to add the `GAUSSIANBLUR_2D` keyword this way:
 
 ```glsl
@@ -211,11 +211,11 @@ Learn more about [LYGIAS design principles in the DESIGN.md file](https://github
 LYGIA has a long way to go and welcomes all kinds of contributions. You can help by:
 
 * **Bug fixing**
-* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc) is a big part of the challenge. Not all language are the same and we want to make sure make sure each function is optimized and carefully crafted for each enviroment. This means, the more eyes looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
+* **Translation**, keeping parity between languages (GLSL, HLSL, MSL, WGSL, TSL, CUDA, OSL, etc) is a big part of the challenge. Not all language are the same and we want to make sure make sure each function is optimized and carefully crafted for each environment. This means, the more eyes looking at this, the better. Please make sure to read and understand the [Design Principles](https://github.com/patriciogonzalezvivo/lygia/blob/main/DESIGN.md) before starting.
 * **New functions or improving the current implementations**. Please take a look to the [Contributing Guidelines](https://github.com/patriciogonzalezvivo/lygia/blob/main/CONTRIBUTING.md) before starting.
 * **Documentation**. Each function has a header with some information describing the function. Make sure to fill this information when adding a new function.
 * Adding new **examples** and integrations for new environments like: [Godot](https://godotengine.org/), [ISF](https://isf.video/), [MaxMSP](https://cycling74.com/products/max), etc.
-* **Financial** [sponsorships](https://github.com/sponsors/patriciogonzalezvivo). Right now, the money that flows in is invested on the server and infraestructure. Long term plan will be to be able to pay lead contributors and mantainers.
+* **Financial** [sponsorships](https://github.com/sponsors/patriciogonzalezvivo). Right now, the money that flows in is invested on the server and infraestructure. Long term plan will be to be able to pay lead contributors and maintainers.
 
 Collaborators and sponsors are automatically added to the [commercial license](https://lygia.xyz/license). Making a PR or subscribing to the github sponsors program is the shortest path to get access to the commercial license. It's all automated, not red taping. LYGIA belongs to those that takes care of it.
 
@@ -231,11 +231,11 @@ If you have doubts please reaching out to patriciogonzalezvivo at gmail dot com
 
 ## Credits
 
-Created and mantained by [Patricio Gonzalez Vivo](https://patriciogonzalezvivo.com/)( <a rel="me" href="https://merveilles.town/@patricio">Mastodon</a> | [Twitter](https://twitter.com/patriciogv) | [Instagram](https://www.instagram.com/patriciogonzalezvivo/) | [GitHub](https://github.com/sponsors/patriciogonzalezvivo) ) and every direct or indirect [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors) to the GitHub. 
+Created and maintained by [Patricio Gonzalez Vivo](https://patriciogonzalezvivo.com/)( <a rel="me" href="https://merveilles.town/@patricio">Mastodon</a> | [Twitter](https://twitter.com/patriciogv) | [Instagram](https://www.instagram.com/patriciogonzalezvivo/) | [GitHub](https://github.com/sponsors/patriciogonzalezvivo) ) and every direct or indirect [contributors](https://github.com/patriciogonzalezvivo/lygia/graphs/contributors) to the GitHub.
 
 This library has been built in many cases on top of the work of brilliant and generous people like: [Inigo Quiles](https://www.iquilezles.org/), [Morgan McGuire](https://casual-effects.com/), [Alan Wolfe](https://blog.demofox.org/), [Matt DesLauriers](https://www.mattdesl.com/), [Bjorn Ottosson](https://github.com/bottosson), [Hugh Kennedy](https://github.com/hughsk), and many others.
 
-Also is being constantly mantain, translated and/or extended by generous contributors like: [Shadi El Hajj](https://github.com/shadielhajj), [Kathy](https://github.com/kfahn22), [Bonsak Schiledrop](https://github.com/bonsak), [Amin Shazrin](https://github.com/ammein), [Guido Schmidt](https://github.com/guidoschmidt), and many others.
+Also is being constantly maintain, translated and/or extended by generous contributors like: [Shadi El Hajj](https://github.com/shadielhajj), [Kathy](https://github.com/kfahn22), [Bonsak Schiledrop](https://github.com/bonsak), [Amin Shazrin](https://github.com/ammein), [Guido Schmidt](https://github.com/guidoschmidt), and many others.
 
 
 

--- a/README_GLSL.md
+++ b/README_GLSL.md
@@ -1,27 +1,27 @@
-LYGIA relies on `#include "path/to/file.glsl"` which is defined by Khronos GLSL standard but it's up to the project developer to implement. Good news is that it's not that hard, it just requires a typical C-like MACRO pre-compiler, which is easy to implement with just basic string operations to resolve dependencies.
+LYGIA relies on `#include "path/to/file.glsl"` to resolve dependencies, which is defined by Khronos GLSL standard, but it's up to the project developer to implement. Good news is that it's not that hard, it just requires a typical C-like MACRO pre-compiler, which is easy to implement with just basic string operations.
 
 Here you can find some examples in different languages:
 
-  - C#:
-  
-    . [GLSLIncludes](https://github.com/seb776/GLSLIncludes) a small utility to add the include feature to glsl by [z0rg](https://github.com/seb776).
+- C#:
 
-  - C++:
+  - [GLSLIncludes](https://github.com/seb776/GLSLIncludes) a small utility to add the include feature to GLSL by [z0rg](https://github.com/seb776).
 
-    . [VERA's routines](https://github.com/patriciogonzalezvivo/vera/blob/main/src/ops/fs.cpp#L110-L171) for resolving GLSL dependencies.
+- C++:
 
-  - Python:
+  - [VERA's routines](https://github.com/patriciogonzalezvivo/vera/blob/main/src/ops/fs.cpp#L110-L171) for resolving GLSL dependencies.
 
-    . [Small and simple routing to resolve includes](https://gist.github.com/patriciogonzalezvivo/9a50569c2ef9b08058706443a39d838e)
+- Python:
 
-  - JavaScript: 
-  
-    . [vanilla JS (online resolver)](https://lygia.xyz/resolve.js) This small file brings `resolveLygia()` which takes a `string` or `string[]` and parses it, solving all the `#include` dependencies into a single `string` you can load on your shaders. It also has a `resolveLygiaAsync()` version that resolves all the dependencies in parallel. Both support dependencies to previous versions of LYGIA by using this pattern `lygia/vX.X.X/...` on you dependency paths. 
-  
-    . [npm module (online resolver)](https://www.npmjs.com/package/resolve-lygia) by Eduardo Fossas. This is bring the same `resolveLygia()` and `resolveLygiaAsync()` function but as a npm module.
+  - [Small and simple routing to resolve includes](https://gist.github.com/patriciogonzalezvivo/9a50569c2ef9b08058706443a39d838e)
 
-    . [vite glsl plugin (local bundle)](https://github.com/UstymUkhman/vite-plugin-glsl) by Ustym Ukhman. Imports `.glsl` local dependencies, or load inline shaders through vite.
-  
-    . [esbuild glsl plugin (local bundle)](https://github.com/ricardomatias/esbuild-plugin-glsl-include) by Ricardo Matias. Imports local `.glsl` dependencies through esbuild.
+- JavaScript:
 
-    . [webpack glsl plugin (local bundle)](https://github.com/grieve/webpack-glsl-loader) by Ryan Grieve that imports local `.glsl` dependencies through webpack.
+  - [vanilla JS (online resolver)](https://lygia.xyz/resolve.js) This small file brings `resolveLygia()` which takes a `string` or `string[]` and parses it, solving all the `#include` dependencies into a single `string` you can load on your shaders. It also has a `resolveLygiaAsync()` version that resolves all the dependencies in parallel. Both support dependencies to previous versions of LYGIA by using this pattern `lygia/vX.X.X/...` on you dependency paths.
+
+  - [npm module (online resolver)](https://www.npmjs.com/package/resolve-lygia) by Eduardo Fossas. This brings the same `resolveLygia()` and `resolveLygiaAsync()` functions but as npm module.
+
+  - [vite glsl plugin (local bundle)](https://github.com/UstymUkhman/vite-plugin-glsl) by Ustym Ukhman. Imports `.glsl` local dependencies, or loads inline shaders through vite.
+
+  - [esbuild glsl plugin (local bundle)](https://github.com/ricardomatias/esbuild-plugin-glsl-include) by Ricardo Matias. Imports local `.glsl` dependencies through esbuild.
+
+  - [webpack glsl plugin (local bundle)](https://github.com/grieve/webpack-glsl-loader) by Ryan Grieve that imports local `.glsl` dependencies through webpack.

--- a/README_METAL.md
+++ b/README_METAL.md
@@ -50,7 +50,7 @@ Metal support is currently highly experimental and very work in progress.
     
 ## Things not yet done
 
-- `gl_FragCoord` compatibilty. Not sure if there is a nice way to make this work without end users annotating their root Metal shader entry point.
+- `gl_FragCoord` compatibility. Not sure if there is a nice way to make this work without end users annotating their root Metal shader entry point.
     - For now, use the function definitions which pass the [[position]] coords from your main shader.
 - `atan` / `atan2` compatibility. Need to see if there is a nice way to override the function signatures to match.
     

--- a/README_METAL.md
+++ b/README_METAL.md
@@ -30,7 +30,7 @@ Metal support is currently highly experimental and very work in progress.
 
 ## Porting Methodology
 
-- dupe `*.glsl` files-> and rename them to  `*.msl`
+- dupe `*.glsl` files -> and rename them to `*.msl`
 - find replace `.glsl` -> `.msl` and ensure you repeat the above for imports
 - find replace `vec2` -> `float2`
 - find replace `vec3` -> `float3`
@@ -44,12 +44,12 @@ Metal support is currently highly experimental and very work in progress.
 
 - Metal does not have the same basic math functions signatures as GLSL. We are adding all the polyfill functions in the `math/` folder.
 - Texture precision and filtering.
-    - Added `SAMPLER_TYPE` which specifies the texture precisions. Defaults to `texture2d<float>`
-    - This means your texture definition must match the default `float` precision, or you will need to override `SAMPLER_TYPE`
-    - Added `SAMPLER` which specifies the Metal sampler object. Defaults to `sampler( min_filter::linear, mag_filter::linear )`
+  - Added `SAMPLER_TYPE` which specifies the texture precisions. Defaults to `texture2d<float>`
+  - This means your texture definition must match the default `float` precision, or you will need to override `SAMPLER_TYPE`
+  - Added `SAMPLER` which specifies the Metal sampler object. Defaults to `sampler( min_filter::linear, mag_filter::linear )`
 
 ## Things not yet done
 
 - `gl_FragCoord` compatibility. Not sure if there is a nice way to make this work without end users annotating their root Metal shader entry point.
-    - For now, use the function definitions which pass the [[position]] coords from your main shader.
+  - For now, use the function definitions which pass the [[position]] coords from your main shader.
 - `atan` / `atan2` compatibility. Need to see if there is a nice way to override the function signatures to match.

--- a/README_METAL.md
+++ b/README_METAL.md
@@ -42,15 +42,14 @@ Metal support is currently highly experimental and very work in progress.
 
 ## Things to look out for
 
-- Metal does not have the same basic math functions signatures as GLSL. We are adding all the polyfill functions in the  `math/` folder.
+- Metal does not have the same basic math functions signatures as GLSL. We are adding all the polyfill functions in the `math/` folder.
 - Texture precision and filtering.
     - Added `SAMPLER_TYPE` which specifies the texture precisions. Defaults to `texture2d<float>`
     - This means your texture definition must match the default `float` precision, or you will need to override `SAMPLER_TYPE`
     - Added `SAMPLER` which specifies the Metal sampler object. Defaults to `sampler( min_filter::linear, mag_filter::linear )`
-    
+
 ## Things not yet done
 
 - `gl_FragCoord` compatibility. Not sure if there is a nice way to make this work without end users annotating their root Metal shader entry point.
     - For now, use the function definitions which pass the [[position]] coords from your main shader.
 - `atan` / `atan2` compatibility. Need to see if there is a nice way to override the function signatures to match.
-    

--- a/color/dither.glsl
+++ b/color/dither.glsl
@@ -7,7 +7,7 @@ options:
     - RESOLUTION: view port resolution
     - BLUENOISE_TEXTURE_RESOLUTION
     - BLUENOISE_TEXTURE
-    - DITHER_TIME: followed with an elipsed secods uniform
+    - DITHER_TIME: followed with an elapsed seconds uniform
     - DITHER_CHROMATIC
     - DITHER_PRECISION
     - SAMPLER_FNC

--- a/color/dither.msl
+++ b/color/dither.msl
@@ -7,7 +7,7 @@ options:
     - RESOLUTION: view port resolution
     - BLUENOISE_TEXTURE_RESOLUTION
     - BLUENOISE_TEXTURE
-    - DITHER_TIME: followed with an elipsed secods uniform
+    - DITHER_TIME: followed with an elapsed seconds uniform
     - DITHER_CHROMATIC
     - DITHER_PRECISION
     - SAMPLER_FNC

--- a/color/dither/shift.glsl
+++ b/color/dither/shift.glsl
@@ -50,8 +50,8 @@ float ditherShift(const in float b, const in vec2 st, const int pres) {
     //Calculate how big the shift should be
     float dither_shift = (0.25) * (1.0 / (pow(2.0,dither_bit) - 1.0));
 
-    //modify shift acording to grid position.
-    dither_shift = mix(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    dither_shift = mix(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
     return b + 0.5/255.0 + dither_shift; 
@@ -77,8 +77,8 @@ vec3 ditherShift(const in vec3 color, const in vec2 st, const int pres) {
     vec3 ditherPattern = vec3(dither_shift);
     #endif
 
-    //modify shift acording to grid position.
-    ditherPattern = mix(2.0 * ditherPattern, -2.0 * ditherPattern, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    ditherPattern = mix(2.0 * ditherPattern, -2.0 * ditherPattern, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
 

--- a/color/dither/shift.hlsl
+++ b/color/dither/shift.hlsl
@@ -35,8 +35,8 @@ float ditherShift(float b, float2 fragcoord, float time) {
     //Calculate how big the shift should be
     float dither_shift = (0.25) * (1.0 / (pow(2.0,dither_bit) - 1.0));
 
-    //modify shift acording to grid position.
-    dither_shift = lerp(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    dither_shift = lerp(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
     return b + 0.5/255.0 + dither_shift; 
@@ -62,8 +62,8 @@ float3 ditherShift(float3 rgb, float2 fragcoord, float time) {
     float3 dither_shift_RGB = float3(dither_shift, dither_shift, dither_shift);
     #endif
 
-    //modify shift acording to grid position.
-    dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
     return rgb + 0.5/255.0 + dither_shift_RGB; 

--- a/color/dither/shift.msl
+++ b/color/dither/shift.msl
@@ -47,8 +47,8 @@ float ditherShift(const float b, const float2 st, const int pres) {
     //Calculate how big the shift should be
     float dither_shift = (0.25) * (1.0 / (pow(2.0,dither_bit) - 1.0));
 
-    //modify shift acording to grid position.
-    dither_shift = mix(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    dither_shift = mix(2.0 * dither_shift, -2.0 * dither_shift, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
     return b + 0.5/255.0 + dither_shift; 
@@ -74,8 +74,8 @@ float3 ditherShift(const float3 color, const float2 st, const int pres) {
     float3 ditherPattern = float3(dither_shift);
     #endif
 
-    //modify shift acording to grid position.
-    ditherPattern = mix(2.0 * ditherPattern, -2.0 * ditherPattern, grid_position); //shift acording to grid position.
+    //modify shift according to grid position.
+    ditherPattern = mix(2.0 * ditherPattern, -2.0 * ditherPattern, grid_position); //shift according to grid position.
 
     //shift the color by dither_shift
 

--- a/color/levels/gamma.glsl
+++ b/color/levels/gamma.glsl
@@ -2,7 +2,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color gamma correction similar to Levels adjusment in Photoshop
+    Color gamma correction similar to Levels adjustment in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsGamma(<vec3|vec4> color, <float|vec3> gamma)
 license:

--- a/color/levels/gamma.hlsl
+++ b/color/levels/gamma.hlsl
@@ -2,7 +2,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color gamma correction similar to Levels adjusment in Photoshop
+    Color gamma correction similar to Levels adjustment in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsGamma(<float3|float4> color, <float|float3> gamma)
 license:

--- a/color/levels/gamma.msl
+++ b/color/levels/gamma.msl
@@ -2,7 +2,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color gamma correction similar to Levels adjusment Photoshop
+    Color gamma correction similar to Levels adjustment Photoshop
     Adapted from RomaDura (http://mouaif.wordpress.com/?p=94)
 use: levelsGamma(<float3|float4> color, <float|float3> gamma)
 license:

--- a/color/levels/inputRange.glsl
+++ b/color/levels/inputRange.glsl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color input range adjustment similar to Levels adjusment tool in Photoshop
+    Color input range adjustment similar to Levels adjustment tool in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsInputRange(<vec3|vec4> color, <float|vec3> minInput, <float|vec3> maxInput)
 license:

--- a/color/levels/inputRange.hlsl
+++ b/color/levels/inputRange.hlsl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color input range adjustment similar to Levels adjusment tool in Photoshop
+    Color input range adjustment similar to Levels adjustment tool in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsInputRange(<float3|float4> color, <float|float3> minInput, <float|float3> maxInput)
 license:

--- a/color/levels/inputRange.msl
+++ b/color/levels/inputRange.msl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color input range adjustment similar to Levels adjusment tool Photoshop
+    Color input range adjustment similar to Levels adjustment tool Photoshop
     Adapted from RomaDura (http://mouaif.wordpress.com/?p=94)
 use: levelsInputRange(<float3|float4> color, <float|float3> minInput, <float|float3> maxInput)
 license:

--- a/color/levels/outputRange.glsl
+++ b/color/levels/outputRange.glsl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color output range adjustment similar to Levels adjusment in Photoshop
+    Color output range adjustment similar to Levels adjustment in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsOutputRange(<vec3|vec4> color, float minOutput, float maxOutput)
 license:

--- a/color/levels/outputRange.hlsl
+++ b/color/levels/outputRange.hlsl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color output range adjustment similar to Levels adjusment in Photoshop
+    Color output range adjustment similar to Levels adjustment in Photoshop
     Adapted from Romain Dura (http://mouaif.wordpress.com/?p=94)
 use: levelsOutputRange(<float3|float4> color, float minOutput, float maxOutput)
 license:

--- a/color/levels/outputRange.msl
+++ b/color/levels/outputRange.msl
@@ -1,7 +1,7 @@
 /*
 contributors: Johan Ismael
 description: |
-    Color output range adjustment similar to Levels adjusment Photoshop
+    Color output range adjustment similar to Levels adjustment Photoshop
     Adapted from RomaDura (http://mouaif.wordpress.com/?p=94)
 use: levelsOutputRange(<float3|float4> color, float minOutput, float maxOutput)
 license:

--- a/color/mixSpectral.glsl
+++ b/color/mixSpectral.glsl
@@ -8,7 +8,7 @@ description: |
     Spectral mix allows you to achieve realistic color mixing in your projects. 
     It is based on the Kubelka-Munk theory, a proven scientific model that simulates 
     how light interacts with paint to produce lifelike color mixing. 
-    Find more informatiom on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
+    Find more information on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
 options:
     - MIXSPECTRAL_SRGB: by default A and B are linear RGB. If you want to use sRGB, define this flag.
 use: <vec3\vec4> mixSpectral(<vec3|vec4> A, <vec3|vec4> B, float pct)

--- a/color/mixSpectral.hlsl
+++ b/color/mixSpectral.hlsl
@@ -8,7 +8,7 @@ description: |
     Spectral mix allows you to achieve realistic color mixing in your projects. 
     It is based on the Kubelka-Munk theory, a proven scientific model that simulates 
     how light interacts with paint to produce lifelike color mixing. 
-    Find more informatiom on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
+    Find more information on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
 options:
     - MIXSPECTRAL_COLORSPACE_SRGB: by default colA and colB are linear RGB. If you want to use sRGB, define this flag.
 use: <float3\float4> mixSpectral(<float3|float4> colA, <float3|float4> colB, float pct)

--- a/color/mixSpectral.msl
+++ b/color/mixSpectral.msl
@@ -8,7 +8,7 @@ description: |
     Spectral mix allows you to achieve realistic color mixing your projects. 
     It is based on the Kubelka-Munk theory, a proven scientific model that simulates 
     how light interacts with paint to produce lifelike color mixing. 
-    Find more informatiom on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
+    Find more information on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
 options:
     - MIXSPECTRAL_SRGB: by default A and B are linear RGB. If you want to use sRGB, define this flag.
 use: <float3\float4> mixSpectral(<float3|float4> A, <float3|float4> B, float pct)

--- a/color/mixSpectral.wgsl
+++ b/color/mixSpectral.wgsl
@@ -6,7 +6,7 @@ description: |
     Spectral mix allows you to achieve realistic color mixing in your projects. 
     It is based on the Kubelka-Munk theory, a proven scientific model that simulates 
     how light interacts with paint to produce lifelike color mixing. 
-    Find more informatiom on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
+    Find more information on Ronald van Wijnen's [original repository](https://github.com/rvanwijnen/spectral.js)
 options:
     - MIXSPECTRAL_SRGB: by default A and B are linear RGB. If you want to use sRGB, define this flag.
 examples:

--- a/color/palette.glsl
+++ b/color/palette.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Inigo Quiles
-description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm)
+description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm
 use: <vec3|vec4> palette(<float> t, <vec3|vec4> a, <vec3|vec4> b, <vec3|vec4> c, <vec3|vec4> d)
 */
 

--- a/color/palette.hlsl
+++ b/color/palette.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Inigo Quiles
-description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm)
+description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm
 use: palette(<float> t, <float3|float4> a, <float3|float4> b, <float3|float4> c, <float3|float4> d)
 */
 

--- a/color/palette.msl
+++ b/color/palette.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Inigo Quiles
-description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm)
+description:  Procedural generation of color palette algorithm explained here http://www.iquilezles.org/www/articles/palettes/palettes.htm
 use: palette(<float> t, <float3|float4> a, <float3|float4> b, <float3|float4> c, <float3|float4> d)
 */
 

--- a/color/space/lch2lab.glsl
+++ b/color/space/lch2lab.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Converts a Lch ot Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
+description: "Converts a Lch to Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
 use: <vec3|vec4> lch2lab(<vec3|vec4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/space/lch2lab.hlsl
+++ b/color/space/lch2lab.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Converts a Lch ot Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
+description: "Converts a Lch to Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
 use: <float3|float4> lch2lab(<float3|float4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/space/lch2lab.msl
+++ b/color/space/lch2lab.msl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Converts a Lch ot Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (degrees).\n"
+description: "Converts a Lch to Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (degrees).\n"
 use: <float3|float4> lch2lab(<float3|float4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/space/lch2lab.wgsl
+++ b/color/space/lch2lab.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Converts a Lch ot Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
+description: "Converts a Lch to Lab color space. \nNote: LCh is simply Lab but converted to polar coordinates (in degrees).\n"
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/color/space/rgb2luma.wgsl
+++ b/color/space/rgb2luma.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: Get's the luminosity from linear RGB, based on Rec709 luminance (see https://en.wikipedia.org/wiki/Grayscale)
+description: Gets the luminosity from linear RGB, based on Rec709 luminance (see https://en.wikipedia.org/wiki/Grayscale)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/color/space/rgb2yiq.glsl
+++ b/color/space/rgb2yiq.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Convert from linear RGB to YIQ which was the followin range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
+description: "Convert from linear RGB to YIQ which was the following range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
 use: rgb2yiq(<vec3|vec4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/space/rgb2yiq.hlsl
+++ b/color/space/rgb2yiq.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Convert from linear RGB to YIQ which was the followin range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
+description: "Convert from linear RGB to YIQ which was the following range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
 use: <float3|float4> rgb2yiq(<float3|float4> color)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/space/rgb2yiq.wgsl
+++ b/color/space/rgb2yiq.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Convert from linear RGB to YIQ which was the followin range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
+description: "Convert from linear RGB to YIQ which was the following range. \nUsing conversion matrices from FCC NTSC Standard (SMPTE C) https://en.wikipedia.org/wiki/YIQ\n"
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/color/space/srgb2luma.wgsl
+++ b/color/space/srgb2luma.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: Get's the luminosity from sRGB. Based on from Rec601 luma (see https://en.wikipedia.org/wiki/Grayscale)
+description: Gets the luminosity from sRGB. Based on from Rec601 luma (see https://en.wikipedia.org/wiki/Grayscale)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/color/whiteBalance.glsl
+++ b/color/whiteBalance.glsl
@@ -14,7 +14,7 @@ contributors:
     - Patricio Gonzalez Vivo
 description: "Adjust temperature and tint. \nOn mobile does a cheaper algo using Brad\
     \ Larson https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageWhiteBalanceFilter.m\
-    \ \nOn non mobile deas a more accurate ajustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
+    \ \nOn non mobile deas a more accurate adjustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
 use: <vec3|vec4> whiteBalance(<vec3|vec4> rgb, <float> temperature, <float> tint))
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
@@ -56,7 +56,7 @@ vec3 whiteBalance(in vec3 rgb, in float temp, in float tint) {
     float S = 0.0030 * X + 0.0136 * Y + 0.9834 * Z;
 
     // Calculate the coefficients in the LMS space.
-    const vec3 w = vec3(0.949237, 1.03542, 1.08728); // D65 white poin
+    const vec3 w = vec3(0.949237, 1.03542, 1.08728); // D65 white point
     vec3 balance = w/vec3(L, M, S);
 
     // TODO: use our own rgb to lms to rgb

--- a/color/whiteBalance.hlsl
+++ b/color/whiteBalance.hlsl
@@ -14,7 +14,7 @@ contributors:
     - Patricio Gonzalez Vivo
 description: "Adjust temperature and tint. \nOn mobile does a cheaper algo using Brad\
     \ Larson https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageWhiteBalanceFilter.m\
-    \ \nOn non mobile deas a more accurate ajustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
+    \ \nOn non mobile deas a more accurate adjustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
 use: <float3|float4> whiteBalance(<float3|float4> rgb, <float> temperature, <float> tint))
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/color/whiteBalance.msl
+++ b/color/whiteBalance.msl
@@ -14,7 +14,7 @@ contributors:
     - Patricio Gonzalez Vivo
 description: "Adjust temperature and tint. \nOn mobile does a cheaper algo using Brad\
     \ Larson https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageWhiteBalanceFilter.m\
-    \ \nOn non mobile deas a more accurate ajustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
+    \ \nOn non mobile deas a more accurate adjustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
 use: <float3|float4> whiteBalance(<float3|float4> rgb, <float> temperature, <float> tint))
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
@@ -56,7 +56,7 @@ float3 whiteBalance(float3 rgb, float temp, float tint) {
     float S = 0.0030 * X + 0.0136 * Y + 0.9834 * Z;
 
     // Calculate the coefficients the LMS space.
-    const float3 w = float3(0.949237, 1.03542, 1.08728); // D65 white poin
+    const float3 w = float3(0.949237, 1.03542, 1.08728); // D65 white point
     float3 balance = w/float3(L, M, S);
 
     // TODO: use our own rgb to lms to rgb

--- a/color/whiteBalance.wgsl
+++ b/color/whiteBalance.wgsl
@@ -14,7 +14,7 @@ contributors:
     - Patricio Gonzalez Vivo
 description: "Adjust temperature and tint. \nOn mobile does a cheaper algo using Brad\
     \ Larson https://github.com/BradLarson/GPUImage/blob/master/framework/Source/GPUImageWhiteBalanceFilter.m\
-    \ \nOn non mobile deas a more accurate ajustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
+    \ \nOn non mobile deas a more accurate adjustment using https://docs.unity3d.com/Packages/com.unity.shadergraph@6.9/manual/White-Balance-Node.html\n"
 use: <vec3|vec4> whiteBalance(<vec3|vec4> rgb, <float> temperature, <float> tint))
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
@@ -44,7 +44,7 @@ fn whiteBalance3(rgb : vec3f, temp : f32, tint : f32) -> vec3f {
     let S = 0.0030 * X + 0.0136 * Y + 0.9834 * Z;
 
     // Calculate the coefficients in the LMS space.
-    let w = vec3(0.949237, 1.03542, 1.08728);  // D65 white poin
+    let w = vec3(0.949237, 1.03542, 1.08728);  // D65 white point
     let balance = w / vec3(L, M, S);
 
     // TODO: use our own rgb to lms to rgb

--- a/distort/chromaAB.glsl
+++ b/distort/chromaAB.glsl
@@ -7,7 +7,7 @@ contributors:
 description: Chroma Aberration
 use: chromaAB(<SAMPLER_TYPE> texture, <vec2> st [, <float|vec2> sdf|offset, <float> pct])
 options:
-    CHROMAAB_TYPE: return type, defauls to vec3
+    CHROMAAB_TYPE: return type, defaults to vec3
     CHROMAAB_PCT: amount of aberration, defaults to 1.5
     CHROMAAB_SAMPLER_FNC: function used to sample the input texture, defaults to texture2D(TEX,
       UV)

--- a/distort/chromaAB.hlsl
+++ b/distort/chromaAB.hlsl
@@ -8,7 +8,7 @@ contributors:
 description: Chroma Aberration
 use: chromaAB(<SAMPLER_TYPE> texture, <float2> st [, <float|float2> sdf|offset, <float> pct])
 options:
-    CHROMAAB_TYPE: return type, defauls to float3
+    CHROMAAB_TYPE: return type, defaults to float3
     CHROMAAB_PCT: amount of aberration, defaults to 1.5
     CHROMAAB_SAMPLER_FNC: function used to sample the input texture, defaults to texture2D(TEX, UV)
     CHROMAAB_CENTER_BUFFER: scalar to attenuate the sdf passed in

--- a/distort/chromaAB.msl
+++ b/distort/chromaAB.msl
@@ -7,7 +7,7 @@ contributors:
 description: Chroma Aberration
 use: chromaAB(<SAMPLER_TYPE> texture, <float2> st [, <float|float2> sdf|offset, <float> pct])
 options:
-    CHROMAAB_TYPE: return type, defauls to float3
+    CHROMAAB_TYPE: return type, defaults to float3
     CHROMAAB_PCT: amount of aberration, defaults to 1.5
     CHROMAAB_SAMPLER_FNC: function used to sample the input texture, defaults to texture2D(TEX,
       UV)

--- a/distort/stretch.glsl
+++ b/distort/stretch.glsl
@@ -9,7 +9,7 @@ use: stretch(<SAMPLER_TYPE> tex, <vec2> st, <vec2> direction [, int samples])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
     - STRETCH_SAMPLES: number of samples taken, defaults to 20
-    - STRETCH_TYPE: return type, defauls to vec4
+    - STRETCH_TYPE: return type, defaults to vec4
     - STRETCH_SAMPLER_FNC(TEX, UV): function used to sample the input texture, defaults to texture2D(tex, TEX, UV)
     - STRETCH_WEIGHT: shaping equation to multiply the sample weight.
 license:

--- a/distort/stretch.hlsl
+++ b/distort/stretch.hlsl
@@ -9,7 +9,7 @@ use: stretch(<SAMPLER_TYPE> tex, <float2> st, <float2> direction [, int samples]
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
     - STRETCH_SAMPLES: number of samples taken, defaults to 20
-    - STRETCH_TYPE: return type, defauls to float4
+    - STRETCH_TYPE: return type, defaults to float4
     - STRETCH_SAMPLER_FNC(TEX, UV): function used to sample the input texture, defaults to texture2D(tex, TEX, UV)
     - STRETCH_WEIGHT: shaping equation to multiply the sample weight.
 license:

--- a/distort/stretch.msl
+++ b/distort/stretch.msl
@@ -9,7 +9,7 @@ use: stretch(<SAMPLER_TYPE> tex, <float2> st, <float2> direction [, int samples]
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
     - STRETCH_SAMPLES: number of samples taken, defaults to 20
-    - STRETCH_TYPE: return type, defauls to float4
+    - STRETCH_TYPE: return type, defaults to float4
     - STRETCH_SAMPLER_FNC(TEX, UV): function used to sample the input texture, defaults to texture2D(tex, TEX, UV)
     - STRETCH_WEIGHT: shaping equation to multiply the sample weight.
 license:

--- a/filter/boxBlur.hlsl
+++ b/filter/boxBlur.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Given a texture return a simple box blured pixel
+description: Given a texture return a simple box blurred pixel
 use: boxBlur(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset)
 options:
     - BOXBLUR_2D: default to 1D

--- a/filter/boxBlur/1D.glsl
+++ b/filter/boxBlur/1D.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple one dimentional box blur, to be applied in two passes
+description: Simple one dimensional box blur, to be applied in two passes
 use: boxBlur1D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/1D.hlsl
+++ b/filter/boxBlur/1D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple one dimentional box blur, to be applied in two passes
+description: Simple one dimensional box blur, to be applied in two passes
 use: boxBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/1D.msl
+++ b/filter/boxBlur/1D.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple one dimentional box blur, to be applied in two passes
+description: Simple one dimensional box blur, to be applied in two passes
 use: boxBlur1D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of msl (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D.glsl
+++ b/filter/boxBlur/2D.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur2D(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D.hlsl
+++ b/filter/boxBlur/2D.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D.msl
+++ b/filter/boxBlur/2D.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur2D(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_offset, <int> kernelSize)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D_fast9.glsl
+++ b/filter/boxBlur/2D_fast9.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D_fast9.hlsl
+++ b/filter/boxBlur/2D_fast9.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/boxBlur/2D_fast9.msl
+++ b/filter/boxBlur/2D_fast9.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo, Anton Marini
-description: Simple two dimentional box blur, so can be apply in a single pass
+description: Simple two dimensional box blur, so can be apply in a single pass
 use: boxBlur1D_fast9(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel_direction)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of msl (texture2D(...) or texture(...))

--- a/filter/jointBilateral.glsl
+++ b/filter/jointBilateral.glsl
@@ -12,7 +12,7 @@ use: bilateralBlur(<SAMPLER_TYPE> texture, <vec2> st, <vec2> duv)
 options:
     - JOINTBILATERAL_TYPE: defaults to vec4
     - JOINTBILATERAL_SAMPLE_FNC(TEX, UV): defaults to sampleClamp2edge(tex, UV)
-    - JOINTBILATERAL_TYPEGUIDE: defualts to vec3
+    - JOINTBILATERAL_TYPEGUIDE: defaults to vec3
     - JOINTBILATERAL_SAMPLEGUIDE_FNC(TEX, UV): defaults to sampleClamp2edge(TEX, UV).rgb
     - JOINTBILATERAL_KERNELSIZE: defaults to  9
     - JOINTBILATERAL_INTENSITY_SIGMA: defaults to 0.026

--- a/filter/noiseBlur.glsl
+++ b/filter/noiseBlur.glsl
@@ -14,7 +14,7 @@ options:
     - NOISEBLUR_TYPE: default to vec3
     - NOISEBLUR_GAUSSIAN_K: no gaussian by default
     - NOISEBLUR_RANDOM23_FNC(UV): defaults to random2(UV)
-    - NOISEBLUR_SAMPLER_FNC(UV): defualts to texture2D(tex, UV).rgb
+    - NOISEBLUR_SAMPLER_FNC(UV): defaults to texture2D(tex, UV).rgb
     - NOISEBLUR_SAMPLES: default to 4
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
 examples:

--- a/filter/noiseBlur.hlsl
+++ b/filter/noiseBlur.hlsl
@@ -20,7 +20,7 @@ options:
     - NOISEBLUR_TYPE: default to float3
     - NOISEBLUR_GAUSSIAN_K: no gaussian by default
     - NOISEBLUR_RANDOM23_FNC(UV): defaults to random2(UV)
-    - NOISEBLUR_SAMPLER_FNC(UV): defualts to texture2D(tex, UV).rgb
+    - NOISEBLUR_SAMPLER_FNC(UV): defaults to texture2D(tex, UV).rgb
     - NOISEBLUR_SAMPLES: default to 4
     - SAMPLER_FNC(TEX, UV): optional depending the target version of HLSL
 license:

--- a/filter/sharpen.glsl
+++ b/filter/sharpen.glsl
@@ -38,8 +38,8 @@ license:
 #ifndef FNC_SHARPEN
 #define FNC_SHARPEN
 
-SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in vec2 st, in vec2 pixel, float strenght) {
-    return SHARPEN_FNC (tex, st, pixel, strenght);
+SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in vec2 st, in vec2 pixel, float strength) {
+    return SHARPEN_FNC (tex, st, pixel, strength);
 }
 
 SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in vec2 st, in vec2 pixel) {

--- a/filter/sharpen.hlsl
+++ b/filter/sharpen.hlsl
@@ -38,8 +38,8 @@ license:
 #ifndef FNC_SHARPEN
 #define FNC_SHARPEN
 
-SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in float2 st, in float2 pixel, float strenght) {
-    return SHARPEN_FNC(tex, st, pixel, strenght);
+SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in float2 st, in float2 pixel, float strength) {
+    return SHARPEN_FNC(tex, st, pixel, strength);
 }
 
 SHARPEN_TYPE sharpen(in SAMPLER_TYPE tex, in float2 st, in float2 pixel) {

--- a/filter/sharpen/adaptive.glsl
+++ b/filter/sharpen/adaptive.glsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: bacondither
-description: Adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
+description: Adaptive sharpening. For strength values between 0.3 <-> 2.0 are a reasonable range 
 use: sharpen(<SAMPLER_TYPE> texture, <vec2> st, <vec2> renderSize [, float streanght])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
@@ -57,7 +57,7 @@ float sharpendAdaptiveControl(in vec4 rgba) { return dot(rgba*rgba, vec4(0.21265
 
 #define SHARPENADAPTIVE_DIFF(pix)   ( abs(blur-c[pix]) )
 
-SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, vec2 st, vec2 pixel, float strenght) {
+SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, vec2 st, vec2 pixel, float strength) {
 
     //-------------------------------------------------------------------------------------------------
 // Defined values under this row are "optimal" DO NOT CHANGE IF YOU DO NOT KNOW WHAT YOU ARE DOING!
@@ -221,7 +221,7 @@ SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, vec2 st, vec2 pixel, floa
     neg_laplace = inversesqrt(weightsum / neg_laplace);
 
     // Compute sharpening magnitude function
-    float sharpen_val = strenght/(strenght*curveslope*pow(edge, 3.5) + 0.625);
+    float sharpen_val = strength/(strength*curveslope*pow(edge, 3.5) + 0.625);
 
     // Calculate sharpening diff and scale
     float sharpdiff = (c0_Y - neg_laplace)*(lowthrsum*sharpen_val + 0.01);

--- a/filter/sharpen/adaptive.hlsl
+++ b/filter/sharpen/adaptive.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: bacondither
-description: Adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range 
+description: Adaptive sharpening. For strength values between 0.3 <-> 2.0 are a reasonable range 
 use: sharpen(<SAMPLER_TYPE> texture, <float2> st, <float2> renderSize [, float streanght])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
@@ -54,7 +54,7 @@ float sharpendAdaptiveControl(in float4 rgba) { return dot(rgba*rgba, float4(0.2
 
 #define SHARPENADAPTIVE_DIFF(pix)   ( abs(blur-c[pix]) )
 
-SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, float2 st, float2 pixel, float strenght) {
+SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, float2 st, float2 pixel, float strength) {
 
     //-------------------------------------------------------------------------------------------------
 // Defined values under this row are "optimal" DO NOT CHANGE IF YOU DO NOT KNOW WHAT YOU ARE DOING!
@@ -219,7 +219,7 @@ SHARPENADAPTIVE_TYPE sharpenAdaptive(SAMPLER_TYPE tex, float2 st, float2 pixel, 
     neg_laplace = rsqrt(weightsum / neg_laplace);
 
     // Compute sharpening magnitude function
-    float sharpen_val = strenght/(strenght*curveslope*pow(edge, 3.5) + 0.625);
+    float sharpen_val = strength/(strength*curveslope*pow(edge, 3.5) + 0.625);
 
     // Calculate sharpening diff and scale
     float sharpdiff = (c0_Y - neg_laplace)*(lowthrsum*sharpen_val + 0.01);

--- a/filter/sharpen/adaptive.wgsl
+++ b/filter/sharpen/adaptive.wgsl
@@ -1,7 +1,7 @@
 
 /*
 contributors: bacondither
-description: Adaptive sharpening. For strenght values between 0.3 <-> 2.0 are a reasonable range
+description: Adaptive sharpening. For strength values between 0.3 <-> 2.0 are a reasonable range
 use: sharpen(<SAMPLER_TYPE> texture, <vec2> st, <vec2> renderSize [, float streanght])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/filter/sharpen/contrastAdaptive.glsl
+++ b/filter/sharpen/contrastAdaptive.glsl
@@ -5,10 +5,10 @@
 contributors: deus0ww
 description: |
     Contrast Adaptive Sharpening - deus0ww - 2020-08-04 
-    Orginal: https://github.com/GPUOpen-Effects/FidelityFX-CAS
+    Original: https://github.com/GPUOpen-Effects/FidelityFX-CAS
     Reshade: https://gist.github.com/SLSNe/bbaf2d77db0b2a2a0755df581b3cf00c
     Reshade: https://gist.github.com/martymcmodding/30304c4bffa6e2bd2eb59ff8bb09d135
-use: sharpenContrastAdaptive(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel, <float> strenght)
+use: sharpenContrastAdaptive(<SAMPLER_TYPE> texture, <vec2> st, <vec2> pixel, <float> strength)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
     - SHARPEN_KERNELSIZE: Defaults 2
@@ -34,8 +34,8 @@ options:
 
 #ifndef FNC_SHARPENADCONTRASTAPTIVE
 #define FNC_SHARPENADCONTRASTAPTIVE
-SHARPENCONTRASTADAPTIVE_TYPE sharpenContrastAdaptive(SAMPLER_TYPE tex, vec2 st, vec2 pixel, float strenght) {
-    float peak = -1.0 / mix(8.0, 5.0, saturate(strenght));
+SHARPENCONTRASTADAPTIVE_TYPE sharpenContrastAdaptive(SAMPLER_TYPE tex, vec2 st, vec2 pixel, float strength) {
+    float peak = -1.0 / mix(8.0, 5.0, saturate(strength));
     
     // fetch a 3x3 neighborhood around the pixel 'e',
     //  a b c

--- a/filter/sharpen/contrastAdaptive.hlsl
+++ b/filter/sharpen/contrastAdaptive.hlsl
@@ -4,10 +4,10 @@
 contributors: deus0ww
 description: |
     Contrast Adaptive Sharpening - deus0ww - 2020-08-04 
-    Orginal: https://github.com/GPUOpen-Effects/FidelityFX-CAS
+    Original: https://github.com/GPUOpen-Effects/FidelityFX-CAS
     Reshade: https://gist.github.com/SLSNe/bbaf2d77db0b2a2a0755df581b3cf00c
     Reshade: https://gist.github.com/martymcmodding/30304c4bffa6e2bd2eb59ff8bb09d135
-use: sharpenContrastAdaptive(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel, <float> strenght)
+use: sharpenContrastAdaptive(<SAMPLER_TYPE> texture, <float2> st, <float2> pixel, <float> strength)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of HLSL
     - SHARPEN_KERNELSIZE: Defaults 2
@@ -33,8 +33,8 @@ options:
 
 #ifndef FNC_SHARPENADCONTRASTAPTIVE
 #define FNC_SHARPENADCONTRASTAPTIVE
-SHARPENCONTRASTADAPTIVE_TYPE sharpenContrastAdaptive(SAMPLER_TYPE tex, float2 st, float2 pixel, float strenght) {
-    float peak = -1.0 / lerp(8.0, 5.0, saturate(strenght));
+SHARPENCONTRASTADAPTIVE_TYPE sharpenContrastAdaptive(SAMPLER_TYPE tex, float2 st, float2 pixel, float strength) {
+    float peak = -1.0 / lerp(8.0, 5.0, saturate(strength));
     
     // fetch a 3x3 neighborhood around the pixel 'e',
     //  a b c

--- a/generative/cnoise.hlsl
+++ b/generative/cnoise.hlsl
@@ -59,8 +59,8 @@ float cnoise(in float3 P) {
     float3 Pi1 = Pi0 + float3(1.0, 1.0, 1.0); // Integer part + 1
     Pi0 = mod289(Pi0);
     Pi1 = mod289(Pi1);
-    float3 Pf0 = frac(P); // Fracional part for interpolation
-    float3 Pf1 = Pf0 - float3(1.0, 1.0, 1.0); // Fracional part - 1.0
+    float3 Pf0 = frac(P); // Fractional part for interpolation
+    float3 Pf1 = Pf0 - float3(1.0, 1.0, 1.0); // Fractional part - 1.0
     float4 ix = float4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
     float4 iy = float4(Pi0.yy, Pi1.yy);
     float4 iz0 = Pi0.zzzz;
@@ -127,8 +127,8 @@ float cnoise(in float4 P) {
     float4 Pi1 = Pi0 + 1.0; // Integer part + 1
     Pi0 = mod289(Pi0);
     Pi1 = mod289(Pi1);
-    float4 Pf0 = frac(P); // Fracional part for interpolation
-    float4 Pf1 = Pf0 - 1.0; // Fracional part - 1.0
+    float4 Pf0 = frac(P); // Fractional part for interpolation
+    float4 Pf1 = Pf0 - 1.0; // Fractional part - 1.0
     float4 ix = float4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
     float4 iy = float4(Pi0.yy, Pi1.yy);
     float4 iz0 = float4(Pi0.zzzz);

--- a/generative/fbm.glsl
+++ b/generative/fbm.glsl
@@ -10,9 +10,9 @@ options:
     FBM_OCTAVES: numbers of octaves. Default is 4.
     FBM_NOISE_FNC(UV): noise function to use Default 'snoise(UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
-    FBM_SCALE_SCALAR: scalar. Defualt is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitud value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitud scalar. Default is 0.5
+    FBM_SCALE_SCALAR: scalar. Default is 2.
+    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
 examples:
     - /shaders/generative_fbm.frag
 license:
@@ -69,13 +69,13 @@ license:
 FBM_NOISE_TYPE fbm(in vec2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE2_FNC(st);
+        value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }
@@ -83,13 +83,13 @@ FBM_NOISE_TYPE fbm(in vec2 st) {
 FBM_NOISE_TYPE fbm(in vec3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE3_FNC(pos);
+        value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }

--- a/generative/fbm.glsl
+++ b/generative/fbm.glsl
@@ -11,8 +11,8 @@ options:
     FBM_NOISE_FNC(UV): noise function to use Default 'snoise(UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
     FBM_SCALE_SCALAR: scalar. Default is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
+    FBM_AMPLITUDE_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUDE_SCALAR: amplitude scalar. Default is 0.5
 examples:
     - /shaders/generative_fbm.frag
 license:
@@ -56,12 +56,12 @@ license:
 #define FBM_SCALE_SCALAR 2.0
 #endif
 
-#ifndef FBM_AMPLITUD_INITIAL
-#define FBM_AMPLITUD_INITIAL 0.5
+#ifndef FBM_AMPLITUDE_INITIAL
+#define FBM_AMPLITUDE_INITIAL 0.5
 #endif
 
-#ifndef FBM_AMPLITUD_SCALAR
-#define FBM_AMPLITUD_SCALAR 0.5
+#ifndef FBM_AMPLITUDE_SCALAR
+#define FBM_AMPLITUDE_SCALAR 0.5
 #endif
 
 #ifndef FNC_FBM
@@ -69,13 +69,13 @@ license:
 FBM_NOISE_TYPE fbm(in vec2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }
@@ -83,13 +83,13 @@ FBM_NOISE_TYPE fbm(in vec2 st) {
 FBM_NOISE_TYPE fbm(in vec3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }

--- a/generative/fbm.hlsl
+++ b/generative/fbm.hlsl
@@ -9,8 +9,8 @@ options:
     FBM_NOISE_FNC(POS_UV): noise function to use Default 'snoise(POS_UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
     FBM_SCALE_SCALAR: scalar. Default is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
+    FBM_AMPLITUDE_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUDE_SCALAR: amplitude scalar. Default is 0.5
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -45,12 +45,12 @@ license:
 #define FBM_SCALE_SCALAR 2.0
 #endif
 
-#ifndef FBM_AMPLITUD_INITIAL
-#define FBM_AMPLITUD_INITIAL 0.5
+#ifndef FBM_AMPLITUDE_INITIAL
+#define FBM_AMPLITUDE_INITIAL 0.5
 #endif
 
-#ifndef FBM_AMPLITUD_SCALAR
-#define FBM_AMPLITUD_SCALAR 0.5
+#ifndef FBM_AMPLITUDE_SCALAR
+#define FBM_AMPLITUDE_SCALAR 0.5
 #endif
 
 #ifndef FNC_FBM
@@ -58,13 +58,13 @@ license:
 FBM_NOISE_TYPE fbm(in float2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_VALUE_INITIAL;
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }
@@ -72,13 +72,13 @@ FBM_NOISE_TYPE fbm(in float2 st) {
 FBM_NOISE_TYPE fbm(in float3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_VALUE_INITIAL;
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }

--- a/generative/fbm.hlsl
+++ b/generative/fbm.hlsl
@@ -8,9 +8,9 @@ options:
     FBM_OCTAVES: numbers of octaves. Default is 4.
     FBM_NOISE_FNC(POS_UV): noise function to use Default 'snoise(POS_UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
-    FBM_SCALE_SCALAR: scalar. Defualt is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitud value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitud scalar. Default is 0.5
+    FBM_SCALE_SCALAR: scalar. Default is 2.
+    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -58,13 +58,13 @@ license:
 FBM_NOISE_TYPE fbm(in float2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_VALUE_INITIAL;
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE2_FNC(st);
+        value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }
@@ -72,13 +72,13 @@ FBM_NOISE_TYPE fbm(in float2 st) {
 FBM_NOISE_TYPE fbm(in float3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_VALUE_INITIAL;
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE3_FNC(pos);
+        value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }

--- a/generative/fbm.msl
+++ b/generative/fbm.msl
@@ -10,9 +10,9 @@ options:
     FBM_OCTAVES: numbers of octaves. Default is 4.
     FBM_NOISE_FNC(UV): noise function to use Default 'snoise(UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
-    FBM_SCALE_SCALAR: scalar. Defualt is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitud value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitud scalar. Default is 0.5
+    FBM_SCALE_SCALAR: scalar. Default is 2.
+    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
 examples:
     - /shaders/generative_fbm.frag
 license:
@@ -69,13 +69,13 @@ license:
 FBM_NOISE_TYPE fbm(float2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE2_FNC(st);
+        value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }
@@ -83,13 +83,13 @@ FBM_NOISE_TYPE fbm(float2 st) {
 FBM_NOISE_TYPE fbm(float3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitud = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUD_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
-        value += amplitud * FBM_NOISE3_FNC(pos);
+        value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitud *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUD_SCALAR;
     }
     return value;
 }

--- a/generative/fbm.msl
+++ b/generative/fbm.msl
@@ -11,8 +11,8 @@ options:
     FBM_NOISE_FNC(UV): noise function to use Default 'snoise(UV)' (simplex noise)
     FBM_VALUE_INITIAL: initial value. Default is 0.
     FBM_SCALE_SCALAR: scalar. Default is 2.
-    FBM_AMPLITUD_INITIAL: initial amplitude value. Default is 0.5
-    FBM_AMPLITUD_SCALAR: amplitude scalar. Default is 0.5
+    FBM_AMPLITUDE_INITIAL: initial amplitude value. Default is 0.5
+    FBM_AMPLITUDE_SCALAR: amplitude scalar. Default is 0.5
 examples:
     - /shaders/generative_fbm.frag
 license:
@@ -56,12 +56,12 @@ license:
 #define FBM_SCALE_SCALAR 2.0
 #endif
 
-#ifndef FBM_AMPLITUD_INITIAL
-#define FBM_AMPLITUD_INITIAL 0.5
+#ifndef FBM_AMPLITUDE_INITIAL
+#define FBM_AMPLITUDE_INITIAL 0.5
 #endif
 
-#ifndef FBM_AMPLITUD_SCALAR
-#define FBM_AMPLITUD_SCALAR 0.5
+#ifndef FBM_AMPLITUDE_SCALAR
+#define FBM_AMPLITUDE_SCALAR 0.5
 #endif
 
 #ifndef FNC_FBM
@@ -69,13 +69,13 @@ license:
 FBM_NOISE_TYPE fbm(float2 st) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE2_FNC(st);
         st *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }
@@ -83,13 +83,13 @@ FBM_NOISE_TYPE fbm(float2 st) {
 FBM_NOISE_TYPE fbm(float3 pos) {
     // Initial values
     FBM_NOISE_TYPE value = FBM_NOISE_TYPE(FBM_VALUE_INITIAL);
-    float amplitude = FBM_AMPLITUD_INITIAL;
+    float amplitude = FBM_AMPLITUDE_INITIAL;
 
     // Loop of octaves
     for (int i = 0; i < FBM_OCTAVES; i++) {
         value += amplitude * FBM_NOISE3_FNC(pos);
         pos *= FBM_SCALE_SCALAR;
-        amplitude *= FBM_AMPLITUD_SCALAR;
+        amplitude *= FBM_AMPLITUDE_SCALAR;
     }
     return value;
 }

--- a/generative/pnoise.hlsl
+++ b/generative/pnoise.hlsl
@@ -60,8 +60,8 @@ float pnoise(in float3 P, in float3 rep) {
     float3 Pi1 = (Pi0 + float3(1.0, 1.0, 1.0)) % rep; // Integer part + 1, mod period
     Pi0 = mod289(Pi0);
     Pi1 = mod289(Pi1);
-    float3 Pf0 = frac(P); // Fracional part for interpolation
-    float3 Pf1 = Pf0 - float3(1.0, 1.0, 1.0); // Fracional part - 1.0
+    float3 Pf0 = frac(P); // Fractional part for interpolation
+    float3 Pf1 = Pf0 - float3(1.0, 1.0, 1.0); // Fractional part - 1.0
     float4 ix = float4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
     float4 iy = float4(Pi0.yy, Pi1.yy);
     float4 iz0 = Pi0.zzzz;
@@ -128,8 +128,8 @@ float pnoise(in float4 P, in float4 rep) {
     float4 Pi1 = (Pi0 + 1.0) % rep; // Integer part + 1 mod rep
     Pi0 = mod289(Pi0);
     Pi1 = mod289(Pi1);
-    float4 Pf0 = frac(P); // Fracional part for interpolation
-    float4 Pf1 = Pf0 - 1.0; // Fracional part - 1.0
+    float4 Pf0 = frac(P); // Fractional part for interpolation
+    float4 Pf1 = Pf0 - 1.0; // Fractional part - 1.0
     float4 ix = float4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
     float4 iy = float4(Pi0.yy, Pi1.yy);
     float4 iz0 = float4(Pi0.zzzz);

--- a/generative/psrdnoise.glsl
+++ b/generative/psrdnoise.glsl
@@ -346,7 +346,7 @@ float psrdnoise(vec3 x, vec3 period, float alpha, out vec3 gradient) {
     vec4 gy = vec4(0.0);
     vec4 gz = vec4(0.0);
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     vec4 qx = St;         // q' = norm ( cross(s, n) )  on the equator
@@ -541,7 +541,7 @@ float psrdnoise(vec3 x, vec3 period, float alpha, out vec3 gradient, out vec3 dg
 
     vec4 gx, gy, gz;
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     vec4 qx = St;         // q' = norm ( cross(s, n) )  on the equator

--- a/generative/psrdnoise.hlsl
+++ b/generative/psrdnoise.hlsl
@@ -346,7 +346,7 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient) {
     float4 gy = float4(0.0, 0.0, 0.0, 0.0);
     float4 gz = float4(0.0, 0.0, 0.0, 0.0);
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     float4 qx = St;         // q' = norm ( cross(s, n) )  on the equator
@@ -544,7 +544,7 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient, out f
 
     float4 gx, gy, gz;
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     float4 qx = St;         // q' = norm ( cross(s, n) )  on the equator

--- a/generative/psrdnoise.msl
+++ b/generative/psrdnoise.msl
@@ -348,7 +348,7 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient) {
     float4 gy = float4(0.0);
     float4 gz = float4(0.0);
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     float4 qx = St;         // q' = norm ( cross(s, n) )  on the equator
@@ -543,7 +543,7 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient, out f
 
     float4 gx, gy, gz;
 
-    // Rotate gradients by angle alpha around a pseudo-random ortogonal axis
+    // Rotate gradients by angle alpha around a pseudo-random orthogonal axis
 #ifdef PSRDNOISE_FAST_ROTATION
     // Fast algorithm, but without dynamic shortcut for alpha = 0
     float4 qx = St;         // q' = norm ( cross(s, n) )  on the equator

--- a/lighting/atmosphere.glsl
+++ b/lighting/atmosphere.glsl
@@ -25,10 +25,10 @@ description: |
     - [License CC0: Stars and galaxy by mrange](https://www.shadertoy.com/view/stBcW1)
 use: <vec3> atmosphere(<vec3> eye_dir, <vec3> sun_dir)
 OPTIONS:
-    ATMOSPHERE_ORIGIN: Defualt vec3(0.0)
+    ATMOSPHERE_ORIGIN: Default vec3(0.0)
     ATMOSPHERE_SUN_POWER: sun power. Default 20.0
-    ATMOSPHERE_LIGHT_SAMPLES: Defualt 8 
-    ATMOSPHERE_SAMPLES: Defualt 16
+    ATMOSPHERE_LIGHT_SAMPLES: Default 8 
+    ATMOSPHERE_SAMPLES: Default 16
     ATMOSPHERE_GROUND: Example vec3( 0.37, 0.35, 0.34 )
     ATMOSPHERE_STARS_LAYERS: Example 3
     ATMOSPHERE_STARS_ELEVATION: Example u_time * 0.01

--- a/lighting/atmosphere.hlsl
+++ b/lighting/atmosphere.hlsl
@@ -24,10 +24,10 @@ description: |
     - [License CC0: Stars and galaxy by mrange](https://www.shadertoy.com/view/stBcW1)
 use: <float3> atmosphere(<float3> eye_dir, <float3> sun_dir)
 OPTIONS:
-    ATMOSPHERE_ORIGIN: Defualt float3(0.0)
+    ATMOSPHERE_ORIGIN: Default float3(0.0)
     ATMOSPHERE_SUN_POWER: sun power. Default 20.0
-    ATMOSPHERE_LIGHT_SAMPLES: Defualt 8 
-    ATMOSPHERE_SAMPLES: Defualt 16
+    ATMOSPHERE_LIGHT_SAMPLES: Default 8 
+    ATMOSPHERE_SAMPLES: Default 16
     ATMOSPHERE_GROUND: Example float3( 0.37, 0.35, 0.34 )
     ATMOSPHERE_STARS_LAYERS: Example 3
     ATMOSPHERE_STARS_ELEVATION: Example u_time * 0.01

--- a/lighting/debugCube.glsl
+++ b/lighting/debugCube.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Ignacio Castaño
-description: Debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
+description: Debugging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
 use: <vec3> debugCube(<vec3> _normal, <float> cube_size, <float> lod)
 */
 

--- a/lighting/debugCube.hlsl
+++ b/lighting/debugCube.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Ignacio Castaño
-description: Debuging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
+description: Debugging cube http://the-witness.net/news/2012/02/seamless-cube-map-filtering/
 use: <float3> debugCube(<float3> _norma, <float> cube_size, <float> lod)
 */
 

--- a/lighting/envMap.glsl
+++ b/lighting/envMap.glsl
@@ -8,7 +8,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-    Get enviroment map light comming from a normal direction and acording
+    Get environment map light coming from a normal direction and according
     to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates
     a fake cube
 use: <vec3> envMap(<vec3> _normal, <float> _roughness [, <float> _metallic])

--- a/lighting/envMap.hlsl
+++ b/lighting/envMap.hlsl
@@ -7,7 +7,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
 description: |
-    Get enviroment map light comming from a normal direction and acording
+    Get environment map light coming from a normal direction and according
     to some roughness/metallic value. If there is no SCENE_CUBEMAP texture it creates
     a fake cube
 use: <float3> envMap(<float3> _normal, <float> _roughness [, <float> _metallic])

--- a/lighting/fresnel.glsl
+++ b/lighting/fresnel.glsl
@@ -6,7 +6,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Resolve fresnel coeficient
+description: Resolve fresnel coefficient
 use:
     - <float|vec3> fresnel(const <float|vec3> f0, <float> NoV)
     - <float|vec3> fresnel(const <float|vec3> f0, <float> NoV, float roughness)

--- a/lighting/fresnel.hlsl
+++ b/lighting/fresnel.hlsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Resolve fresnel coeficient
+description: Resolve fresnel coefficient
 use:
     - <float3> fresnel(const <float3> f0, <float> NoV)
     - <float3> fresnel(const <float3> f0, <float> NoV, float roughness)

--- a/lighting/fresnel.wgsl
+++ b/lighting/fresnel.wgsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Resolve fresnel coeficient
+description: Resolve fresnel coefficient
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/lighting/fresnelReflection.glsl
+++ b/lighting/fresnelReflection.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Resolve fresnel coeficient and apply it to a reflection. It can apply\
+description: "Resolve fresnel coefficient and apply it to a reflection. It can apply\
     \ iridescence to \nusing a formula based on https://www.alanzucconi.com/2017/07/25/the-mathematics-of-thin-film-interference/\n"
 use:
     - <vec3> fresnelReflection(<vec3> R, <vec3> f0, <float> NoV)

--- a/lighting/fresnelReflection.hlsl
+++ b/lighting/fresnelReflection.hlsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Resolve fresnel coeficient and apply it to a reflection. It can apply\
+description: "Resolve fresnel coefficient and apply it to a reflection. It can apply\
     \ iridescence to \nusing a formula based on https://www.alanzucconi.com/2017/07/25/the-mathematics-of-thin-film-interference/\n"
 use:
     - <float3> fresnelReflection(<float3> R, <float3> f0, <float> NoV)

--- a/lighting/fresnelReflection.wgsl
+++ b/lighting/fresnelReflection.wgsl
@@ -3,7 +3,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Resolve fresnel coeficient and apply it to a reflection. It can apply\
+description: "Resolve fresnel coefficient and apply it to a reflection. It can apply\
     \ iridescence to \nusing a formula based on https://www.alanzucconi.com/2017/07/25/the-mathematics-of-thin-film-interference/\n"
 use:
     - <vec3> fresnelReflection(<vec3> R, <vec3> f0, <float> NoV)

--- a/lighting/gooch.glsl
+++ b/lighting/gooch.glsl
@@ -13,9 +13,9 @@ contributors: Patricio Gonzalez Vivo
 description: Render with a gooch stylistic shading model
 use: <vec4> gooch(<vec4> albedo, <vec3> normal, <vec3> light, <vec3> view, <float> roughness)
 options:
-    - GOOCH_WARM: defualt vec3(0.25, 0.15, 0.0)
-    - GOOCH_COLD: defualt vec3(0.0, 0.0, 0.2)
-    - GOOCH_SPECULAR: defualt vec3(1.0, 1.0, 1.0)
+    - GOOCH_WARM: default vec3(0.25, 0.15, 0.0)
+    - GOOCH_COLD: default vec3(0.0, 0.0, 0.2)
+    - GOOCH_SPECULAR: default vec3(1.0, 1.0, 1.0)
     - DIFFUSE_FNC: diffuseOrenNayar, diffuseBurley, diffuseLambert (default)
     - LIGHT_COORD: in GlslViewer is  v_lightCoord
     - LIGHT_SHADOWMAP: in GlslViewer is u_lightShadowMap

--- a/lighting/material/metallic.glsl
+++ b/lighting/material/metallic.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
+description: Get material metallic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
 use: vec4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/metallic.hlsl
+++ b/lighting/material/metallic.hlsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Get material metalic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
+description: Get material metallic property from GlslViewer's defines https://github.com/patriciogonzalezvivo/glslViewer/wiki/GlslViewer-DEFINES#material-defines
 use: float4 materialMetallic()
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/lighting/material/multiply.glsl
+++ b/lighting/material/multiply.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Shadi El Hajj
-description: Mutiply material properties by a constant, store result in r
+description: Multiply material properties by a constant, store result in r
 license: MIT License (MIT) Copyright (c) 2024 Shadi EL Hajj
 */
 

--- a/lighting/material/multiply.hlsl
+++ b/lighting/material/multiply.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Shadi El Hajj
-description: Mutiply material properties by a constant, store result in r
+description: Multiply material properties by a constant, store result in r
 license: MIT License (MIT) Copyright (c) 2024 Shadi EL Hajj
 */
 

--- a/lighting/ray/new.glsl
+++ b/lighting/ray/new.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Creates a new Ray asigning origin and direction
+description: Creates a new Ray assigning origin and direction
 use:
     - rayNew(inout <Ray> ray, [<vec3> origin, <vec3> direction])
     - <Ray> rayNew(<vec3> origin, [<vec3> direction])

--- a/lighting/raymarch/fog.glsl
+++ b/lighting/raymarch/fog.glsl
@@ -45,7 +45,7 @@ vec3 raymarchColorFog(in vec3 col,      // color of pixel
 }
 
 vec3 raymarchHeightFog( in vec3 col,     // color of pixel
-                        in float t,      // distnace to point
+                        in float t,      // distance to point
                         in vec3 ro,      // camera position
                         in vec3 rd) {    // camera to point vector
     float fogAmount = (FOG_DENSITY / FOG_FALLOFF) * exp(-ro.y * FOG_FALLOFF) * (1.0 - exp(-t * rd.y * FOG_FALLOFF)) / rd.y;

--- a/lighting/raymarch/fog.hlsl
+++ b/lighting/raymarch/fog.hlsl
@@ -47,7 +47,7 @@ float3 raymarchColorFog(in float3 col, // color of pixel
 }
 
 float3 raymarchHeightFog(in float3 col, // color of pixel
-                   in float t,    // distnace to point
+                   in float t,    // distance to point
                    in float3 ro,  // camera position
                    in float3 rd)  // camera to point vector
 {

--- a/lighting/raymarch/glass.glsl
+++ b/lighting/raymarch/glass.glsl
@@ -13,7 +13,7 @@ options:
     - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic aberration effects]
     - RAYMARCH_GLASS_ENABLE_REFLECTION                  [Define this option to enable reflection]
     - RAYMARCH_GLASS_REFLECTION_EFFECT 5.               [The higher the value, the less reflections area from surface view]
-    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Aberration Effects value on environment map]
+    - RAYMARCH_GLASS_CHROMATIC_ABERRATION .01           [Chromatic Aberration Effects value on environment map]
     - RAYMARCH_GLASS_EDGE_SHARPNESS                     [Optional, to determine the edge sharpness]
     - RAYMARCH_GLASS_FNC_MANUAL                         [Optional, enable this to set glass params manually without using defines]
     - RAYMARCH_GLASS_FNC(RAY,POSITION,IOR,ROUGHNESS)
@@ -42,8 +42,8 @@ examples:
 #define RAYMARCH_GLASS_FNC(RAY, POSITION, IOR, ROUGHNESS) raymarchDefaultGlass(RAY, POSITION, IOR, ROUGHNESS)
 #endif
 
-#ifndef RAYMARCH_GLASS_CHROMATIC_ABBERATION
-#define RAYMARCH_GLASS_CHROMATIC_ABBERATION .01
+#ifndef RAYMARCH_GLASS_CHROMATIC_ABERRATION
+#define RAYMARCH_GLASS_CHROMATIC_ABERRATION .01
 #endif
 
 #ifndef RAYMARCH_GLASS_SAMPLES
@@ -238,7 +238,7 @@ vec4 raymarchDefaultGlass(in vec3 ray, in vec3 pos, in float ior, in float rough
             RAYMARCH_GLASS_WAVELENGTH_MAP_FNC(res, rdIn, rdOut, pEnter, pExit, nEnter, nExit, ior, roughness);
         #else
             // Red
-            rdOut = refract(rdIn, nExit, ior - RAYMARCH_GLASS_CHROMATIC_ABBERATION);
+            rdOut = refract(rdIn, nExit, ior - RAYMARCH_GLASS_CHROMATIC_ABERRATION);
 
             if(dot(rdOut, rdOut) == 0.)
                 rdOut = reflect(rdIn, nExit);
@@ -254,7 +254,7 @@ vec4 raymarchDefaultGlass(in vec3 ray, in vec3 pos, in float ior, in float rough
             res.g = envMap(rdOut, roughness).g;
 
             // Blue
-            rdOut = refract(rdIn, nExit, ior + RAYMARCH_GLASS_CHROMATIC_ABBERATION);
+            rdOut = refract(rdIn, nExit, ior + RAYMARCH_GLASS_CHROMATIC_ABERRATION);
 
             if(dot(rdOut, rdOut) == 0.)
                 rdOut = reflect(rdIn, nExit);

--- a/lighting/raymarch/glass.glsl
+++ b/lighting/raymarch/glass.glsl
@@ -10,10 +10,10 @@ use: <vec3> raymarchGlass( in <vec3> ray, in <vec3> pos, in <float> ior, in <flo
 options:
     - RAYMARCH_GLASS_DENSITY: 0.                        [Density of the ray going through the glass]
     - RAYMARCH_GLASS_COLOR: vec3(1.0, 1.0, 1.0)       [Color of the glass]
-    - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic abberation effects]
+    - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic aberration effects]
     - RAYMARCH_GLASS_ENABLE_REFLECTION                  [Define this option to enable reflection]
     - RAYMARCH_GLASS_REFLECTION_EFFECT 5.               [The higher the value, the less reflections area from surface view]
-    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Abberation Effects value on environment map]
+    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Aberration Effects value on environment map]
     - RAYMARCH_GLASS_EDGE_SHARPNESS                     [Optional, to determine the edge sharpness]
     - RAYMARCH_GLASS_FNC_MANUAL                         [Optional, enable this to set glass params manually without using defines]
     - RAYMARCH_GLASS_FNC(RAY,POSITION,IOR,ROUGHNESS)

--- a/lighting/raymarch/glass.hlsl
+++ b/lighting/raymarch/glass.hlsl
@@ -10,10 +10,10 @@ use: <float3> raymarchGlass( in <float3> ray, in <float3> pos, in <float> ior, i
 options:
     - RAYMARCH_GLASS_DENSITY: 0.                        [Density of the ray going through the glass]
     - RAYMARCH_GLASS_COLOR: float3(1.0, 1.0, 1.0)       [Color of the glass]
-    - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic abberation effects]
+    - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic aberration effects]
     - RAYMARCH_GLASS_ENABLE_REFLECTION                  [Define this option to enable reflection]
     - RAYMARCH_GLASS_REFLECTION_EFFECT 5.               [The higher the value, the less reflections area from surface view]
-    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Abberation Effects on environment map]
+    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Aberration Effects on environment map]
     - RAYMARCH_GLASS_EDGE_SHARPNESS                     [Optional, to determine the edge sharpness]
     - RAYMARCH_GLASS_FNC_MANUAL                         [Optional, enable this to set glass params manually without using defines]
     - RAYMARCH_GLASS_FNC(RAY,POSITION,IOR,ROUGHNESS)

--- a/lighting/raymarch/glass.hlsl
+++ b/lighting/raymarch/glass.hlsl
@@ -13,7 +13,7 @@ options:
     - RAYMARCH_GLASS_WAVELENGTH                         [Define this option to enable chromatic aberration effects]
     - RAYMARCH_GLASS_ENABLE_REFLECTION                  [Define this option to enable reflection]
     - RAYMARCH_GLASS_REFLECTION_EFFECT 5.               [The higher the value, the less reflections area from surface view]
-    - RAYMARCH_GLASS_CHROMATIC_ABBERATION .01           [Chromatic Aberration Effects on environment map]
+    - RAYMARCH_GLASS_CHROMATIC_ABERRATION .01           [Chromatic Aberration Effects on environment map]
     - RAYMARCH_GLASS_EDGE_SHARPNESS                     [Optional, to determine the edge sharpness]
     - RAYMARCH_GLASS_FNC_MANUAL                         [Optional, enable this to set glass params manually without using defines]
     - RAYMARCH_GLASS_FNC(RAY,POSITION,IOR,ROUGHNESS)
@@ -39,8 +39,8 @@ options:
 #define RAYMARCH_GLASS_FNC(RAY, POSITION, IOR, ROUGHNESS) raymarchDefaultGlass(RAY, POSITION, IOR, ROUGHNESS)
 #endif
 
-#ifndef RAYMARCH_GLASS_CHROMATIC_ABBERATION
-#define RAYMARCH_GLASS_CHROMATIC_ABBERATION .01
+#ifndef RAYMARCH_GLASS_CHROMATIC_ABERRATION
+#define RAYMARCH_GLASS_CHROMATIC_ABERRATION .01
 #endif
 
 #ifndef RAYMARCH_GLASS_SAMPLES
@@ -236,7 +236,7 @@ float3 raymarchDefaultGlass(in float3 ray, in float3 pos, in float ior, in float
             RAYMARCH_GLASS_WAVELENGTH_MAP_FNC(res, rdIn, rdOut, pEnter, pExit, nEnter, nExit, ior, roughness);
         #else
             // Red
-            rdOut = refract(rdIn, nExit, ior - RAYMARCH_GLASS_CHROMATIC_ABBERATION);
+            rdOut = refract(rdIn, nExit, ior - RAYMARCH_GLASS_CHROMATIC_ABERRATION);
 
             if(dot(rdOut, rdOut) == 0.)
                 rdOut = reflect(rdIn, nExit);
@@ -252,7 +252,7 @@ float3 raymarchDefaultGlass(in float3 ray, in float3 pos, in float ior, in float
             res.g = envMap(rdOut, roughness).g;
 
             // Blue
-            rdOut = refract(rdIn, nExit, ior + RAYMARCH_GLASS_CHROMATIC_ABBERATION);
+            rdOut = refract(rdIn, nExit, ior + RAYMARCH_GLASS_CHROMATIC_ABERRATION);
 
             if(dot(rdOut, rdOut) == 0.)
                 rdOut = reflect(rdIn, nExit);

--- a/math/decimate.cuh
+++ b/math/decimate.cuh
@@ -3,8 +3,8 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: decimate a value with an specific presicion
-use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> presicion)
+description: decimate a value with an specific precision
+use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> precision)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -12,5 +12,5 @@ license:
 
 #ifndef FNC_DECIMATE
 #define FNC_DECIMATE
-#define decimate(value, presicion) (floor(value * presicion)/presicion)
+#define decimate(value, precision) (floor(value * precision)/precision)
 #endif

--- a/math/decimate.glsl
+++ b/math/decimate.glsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: decimate a value with an specific presicion
-use: <float|vec2|vec3|vec4> decimate(<float|vec2|vec3|vec4> value, <float|vec2|vec3|vec4> presicion)
+description: decimate a value with an specific precision
+use: <float|vec2|vec3|vec4> decimate(<float|vec2|vec3|vec4> value, <float|vec2|vec3|vec4> precision)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_functions.frag
 license:

--- a/math/decimate.hlsl
+++ b/math/decimate.hlsl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: decimate a value with an specific presicion
-use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> presicion)
+description: decimate a value with an specific precision
+use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> precision)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/math/decimate.msl
+++ b/math/decimate.msl
@@ -1,7 +1,7 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: decimate a value with an specific presicion
-use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> presicion)
+description: decimate a value with an specific precision
+use: <float|float2|float3|float4> decimate(<float|float2|float3|float4> value, <float|float2|float3|float4> precision)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_functions.frag
 license:

--- a/math/decimate.wgsl
+++ b/math/decimate.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: decimate a value with an specific presicion
+description: decimate a value with an specific precision
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/math/gaussian.cuh
+++ b/math/gaussian.cuh
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 use: <float4|float3|float2|float> gaussian(<float> sigma, <float4|float3|float2|float> d)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/gaussian.glsl
+++ b/math/gaussian.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 use: <vec4|vec3|vec2|float> gaussian(<float> sigma, <vec4|vec3|vec2|float> d)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_gaussian.frag

--- a/math/gaussian.hlsl
+++ b/math/gaussian.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 use: <float4|float3|float2|float> gaussian(<float4|float3|float2|float> d, <float> sigma)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/gaussian.msl
+++ b/math/gaussian.msl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 use: <float4|float3|float2|float> gaussian(<float> sigma, <float4|float3|float2|float> d)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_gaussian.frag

--- a/math/gaussian.msl 2
+++ b/math/gaussian.msl 2
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 use: <float4|float3|float2|float> gaussian(<float> sigma, <float4|float3|float2|float> d)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/math_gaussian.frag

--- a/math/gaussian.wgsl
+++ b/math/gaussian.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: gaussian coeficient
+description: gaussian coefficient
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license

--- a/math/inside.msl
+++ b/math/inside.msl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: does the position lie withthe triangle
+description: does the position lie within the triangle
 use:
     - bool inside(<float|float2|float3> value, <float|float2|float3> min, <float|float2|float3> max)
     - bool inside(<float2|float3> value, <float4|AABB> aabb)

--- a/math/quat/length.glsl
+++ b/math/quat/length.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: 'Returns the lenght of a quaternion'
+description: 'Returns the length of a quaternion'
 use: <QUAT> quatLength(<QUAT> q)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/length.hlsl
+++ b/math/quat/length.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: 'Returns the lenght of a quaternion'
+description: 'Returns the length of a quaternion'
 use: <QUAT> quatLength(<QUAT> q)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/length.msl
+++ b/math/quat/length.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: 'Returns the lenght of a quaternion'
+description: 'Returns the length of a quaternion'
 use: <QUAT> quatLength(<QUAT> q)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/length.wgsl
+++ b/math/quat/length.wgsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: 'Returns the lenght of a quaternion'
+description: 'Returns the length of a quaternion'
 use: <QUAT> quatLength(<QUAT> q)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/lerp.msl
+++ b/math/quat/lerp.msl
@@ -2,7 +2,7 @@
 contributors: Patricio Gonzalez Vivo
 description: |
     Linear interpolation between two quaternions.
-    This function is based on the implementation of slerp() found inthe GLM library.
+    This function is based on the implementation of slerp() found in the GLM library.
 use: <QUAT> quatLerp(<QUAT> a, <QUAT> b, <float> t)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/sub.glsl
+++ b/math/quat/sub.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Quaternion substraction. \n"
+description: "Quaternion subtraction. \n"
 use: <QUAT> quatNeg(<QUAT> a, <QUAT> b)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/sub.hlsl
+++ b/math/quat/sub.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Quaternion substraction. \n"
+description: "Quaternion subtraction. \n"
 use: <QUAT> quatNeg(<QUAT> a, <QUAT> b)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/sub.msl
+++ b/math/quat/sub.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Quaternion substraction. \n"
+description: "Quaternion subtraction. \n"
 use: <QUAT> quatNeg(<QUAT> a, <QUAT> b)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/math/quat/sub.wgsl
+++ b/math/quat/sub.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: "Quaternion substraction. \n"
+description: "Quaternion subtraction. \n"
 use: <QUAT> quatNeg(<QUAT> a, <QUAT> b)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/morphological/marchingSquares.glsl
+++ b/morphological/marchingSquares.glsl
@@ -6,7 +6,7 @@
 contributors: Guido Schmidt
 description: |
     The Marching Squares algorithm generates contour lines (isolines) of a given input for a
-    given grid and a threshhold. Is uses a lookup of 16 cases to decide if a cell is inside, outside or
+    given grid and a threshold. Is uses a lookup of 16 cases to decide if a cell is inside, outside or
     a specific corner.
     **References:**
     - [urbanspr1nter.github.io](https://urbanspr1nter.github.io/marchingsquares/)

--- a/sample/derivative.glsl
+++ b/sample/derivative.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sample derrivatives
+description: sample derivatives
 use: sampleDerivative(<SAMPLER_TYPE> tex, <vec2> st)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (tex2D(...) or texture(...))

--- a/sample/derivative.hlsl
+++ b/sample/derivative.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sample derrivatives
+description: sample derivatives
 use: sampleDerivative(<SAMPLER_TYPE> tex, <float2> st)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (tex2D(...) or texture(...))

--- a/sample/normalMap.glsl
+++ b/sample/normalMap.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Standar way to get normals from a normal map
+description: Standard way to get normals from a normal map
 use: sampleNormal(<SAMPLER_TYPE> tex, <vec2> st)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/sample/normalMap.hlsl
+++ b/sample/normalMap.hlsl
@@ -2,7 +2,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: Standar way to get normals from a normal map
+description: Standard way to get normals from a normal map
 use: sampleNormal(<SAMPLER_TYPE> tex, <float2> st)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/sample/viewPosition.glsl
+++ b/sample/viewPosition.glsl
@@ -5,7 +5,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sampler the view Positiong from depthmap texture
+description: sample the view Position from depthmap texture
 use: <vec4> sampleViewPosition(<SAMPLER_TYPE> texDepth, <vec2> st [, <float> near, <float> far])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/sample/viewPosition.hlsl
+++ b/sample/viewPosition.hlsl
@@ -4,7 +4,7 @@
 
 /*
 contributors: Patricio Gonzalez Vivo
-description: sampler the view Positiong from depthmap texture
+description: sample the view Position from depthmap texture
 use: <float4> sampleViewPosition(<SAMPLER_TYPE> texDepth, <float2> st [, <float> near, <float> far])
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))

--- a/sdf/opSubtraction.glsl
+++ b/sdf/opSubtraction.glsl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: Substraction operation of two SDFs 
+description: Subtraction operation of two SDFs 
 use: <float> opSubstraction( in <float> d1, in <float> d2 [, <float> smooth_factor]) 
 */
 

--- a/sdf/opSubtraction.hlsl
+++ b/sdf/opSubtraction.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors:  Inigo Quiles
-description: Substraction operation of two SDFs 
+description: Subtraction operation of two SDFs 
 use: <float> opSubstraction( in <float> d1, in <float> d2 [, <float> smooth_factor]) 
 */
 

--- a/sdf/opSubtraction.msl
+++ b/sdf/opSubtraction.msl
@@ -2,7 +2,7 @@
 
 /*
 contributors:  Inigo Quiles
-description: Substraction operation of two SDFs 
+description: Subtraction operation of two SDFs 
 use: <float> opSubstraction( <float> d1, <float> d2 [, <float> smooth_factor]) 
 */
 

--- a/sdf/opSubtraction.wgsl
+++ b/sdf/opSubtraction.wgsl
@@ -1,6 +1,6 @@
 /*
 contributors: Inigo Quiles
-description: Substraction operation of two SDFs
+description: Subtraction operation of two SDFs
 
 */
 

--- a/sdf/superShapeSDF.glsl
+++ b/sdf/superShapeSDF.glsl
@@ -8,10 +8,10 @@ description: |
 
         * `m` determines number of sides/branches
         * `m = 0` yields a circle
-        * `a!=b` results in an assymetrical shape
+        * `a!=b` results in an asymmetrical shape
         * `n1=n2=n3<1` the shape is "pinched"
         * `n1>n2,n3` the shape is "bloated"
-        * `n1!=n2!=n3` the shape is assymetrical
+        * `n1!=n2!=n3` the shape is asymmetrical
         * `n1=n2=n3=1` the shape is a square
         * `n1=n2=n3=2` the shape is a star
 

--- a/sdf/superShapeSDF.hlsl
+++ b/sdf/superShapeSDF.hlsl
@@ -8,10 +8,10 @@ description: |
 
         * `m` determines number of sides/branches
         * `m = 0` yields a circle
-        * `a!=b` results in an assymetrical shape
+        * `a!=b` results in an asymmetrical shape
         * `n1=n2=n3<1` the shape is "pinched"
         * `n1>n2,n3` the shape is "bloated"
-        * `n1!=n2!=n3` the shape is assymetrical
+        * `n1!=n2!=n3` the shape is asymmetrical
 
 use: <float> supershapeSDF(<float2> st, <float> size s, <float> a, <float> b, <float> n1, <float> n2, <float> n3, <float> m)
 */

--- a/sdf/superShapeSDF.msl
+++ b/sdf/superShapeSDF.msl
@@ -8,10 +8,10 @@ description: |
 
         * `m` determines number of sides/branches
         * `m = 0` yields a circle
-        * `a!=b` results an assymetrical shape
+        * `a!=b` results an asymmetrical shape
         * `n1=n2=n3<1` the shape is "pinched"
         * `n1>n2,n3` the shape is "bloated"
-        * `n1!=n2!=n3` the shape is assymetrical
+        * `n1!=n2!=n3` the shape is asymmetrical
         * `n1=n2=n3=1` the shape is a square
         * `n1=n2=n3=2` the shape is a star
 

--- a/simulate/latticeBoltzmann.glsl
+++ b/simulate/latticeBoltzmann.glsl
@@ -4,7 +4,7 @@
 /*
 original_author: Patricio Gonzalez Vivo
 description: |
-    Stable fluid simlation inspired on Lattice Boltzmann method described in https://wyattflanders.com/MeAndMyNeighborhood.pdf
+    Stable fluid simulation inspired on Lattice Boltzmann method described in https://wyattflanders.com/MeAndMyNeighborhood.pdf
     Where the reading texture is structure as follow
         XY is the ordered energy that (moves the bubble)
         B disordered energy that evaporates
@@ -34,14 +34,14 @@ vec4 latticeBoltzmannPrevPosSampler(sampler2D tex, vec2 st, vec2 pixel) {
 vec4 latticeBoltzmann(sampler2D tex, vec2 st, vec2 pixel) {
     vec4 d = latticeBoltzmannPrevPosSampler(tex, st, pixel);
 
-    // Neightbors
+    // Neighbors
     vec4 pX   = latticeBoltzmannPrevPosSampler(tex, st + vec2(pixel.x,0.0), pixel);
     vec4 pY   = latticeBoltzmannPrevPosSampler(tex, st + vec2(0.0,pixel.y), pixel);
     vec4 nX   = latticeBoltzmannPrevPosSampler(tex, st - vec2(pixel.x,0.0), pixel);
     vec4 nY   = latticeBoltzmannPrevPosSampler(tex, st - vec2(0.0,pixel.y), pixel);
     
     // Rule 2: Disordered diffuses completely.
-    //  All of My disordered Energy B comes fromm y neighborhood.
+    //  All of my disordered Energy B comes from my neighborhood.
     //  Exchange disorder symmetrically in all direction
     d.b = (pX.b + pY.b + nX.b + nY.b) * 0.25;
     

--- a/simulate/simpleAndFastFluid.glsl
+++ b/simulate/simpleAndFastFluid.glsl
@@ -4,14 +4,14 @@
 /*
 original_author: Patricio Gonzalez Vivo
 description: |
-    Simple single pass fluid simlation from the book GPU Pro 2, "Simple and Fast Fluids" . https://inria.hal.science/inria-00596050/document
+    Simple single pass fluid simulation from the book GPU Pro 2, "Simple and Fast Fluids" . https://inria.hal.science/inria-00596050/document
     The algorithm uses a Jacobi iteration method to solve for the density and incorporates semi-Lagrangian advection
 
 use: <vec2> simpleAndFastFluid(<SAMPLER_TYPE> tex, <vec2> st, <vec2> pixel, <vec2> force)
 options:
     - SAMPLER_FNC(TEX, UV): optional depending the target version of GLSL (texture2D(...) or texture(...))
     - SIMPLEANDFASTFLUID_DT: Default, 0.15
-    - SIMPLEANDFASTFLUID_DX: Defailt, 1.0
+    - SIMPLEANDFASTFLUID_DX: Default, 1.0
     - SIMPLEANDFASTFLUID_BOUNDARY: apply set to true if you want to use the boundary conditions
     - SIMPLEANDFASTFLUID_VORTICITY: lower value for vorticity threshold means higher viscosity and vice versa (max .3)
     - SIMPLEANDFASTFLUID_VISCOSITY: Default, 0.16

--- a/space/displace.glsl
+++ b/space/displace.glsl
@@ -39,7 +39,7 @@ vec3 displace(SAMPLER_TYPE tex, vec3 ro, vec3 rd) {
     float dz = ro.z - DISPLACE_DEPTH;
     float t = dz / rd.z;
 
-    // the intersection point between the ray and the hightest point on the plane
+    // the intersection point between the ray and the highest point on the plane
     vec3 prev = vec3(
         ro.x - rd.x * t,
         ro.y - rd.y * t,

--- a/space/displace.hlsl
+++ b/space/displace.hlsl
@@ -34,7 +34,7 @@ float3 displace(SAMPLER_TYPE tex, float3 ro, float3 rd) {
     float dz = ro.z - DISPLACE_DEPTH;
     float t = dz / rd.z;
 
-    // the intersection point between the ray and the hightest point on the plane
+    // the intersection point between the ray and the highest point on the plane
     float3 prev = float3(
         ro.x - rd.x * t,
         ro.y - rd.y * t,

--- a/space/displace.msl
+++ b/space/displace.msl
@@ -39,7 +39,7 @@ float3 displace(SAMPLER_TYPE tex, float3 ro, float3 rd) {
     float dz = ro.z - DISPLACE_DEPTH;
     float t = dz / rd.z;
 
-    // the intersection point between the ray and the hightest point on the plane
+    // the intersection point between the ray and the highest point on the plane
     float3 prev = float3(
         ro.x - rd.x * t,
         ro.y - rd.y * t,

--- a/space/hexTile.glsl
+++ b/space/hexTile.glsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: make some hexagonal tiles. XY provide coordenates of the tile. While Z provides the distance to the center of the tile
+description: make some hexagonal tiles. XY provide coordinates of the tile. While Z provides the distance to the center of the tile
 use: <vec4> hexTile(<vec2> st)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/draw_tiles.frag

--- a/space/hexTile.hlsl
+++ b/space/hexTile.hlsl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: make some hexagonal tiles. XY provide coordenates of the tile. While Z provides the distance to the center of the tile
+description: make some hexagonal tiles. XY provide coordinates of the tile. While Z provides the distance to the center of the tile
 use: <float4> hexTile(<float2> st)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0

--- a/space/hexTile.msl
+++ b/space/hexTile.msl
@@ -1,6 +1,6 @@
 /*
 contributors: Patricio Gonzalez Vivo
-description: make some hexagonal tiles. XY provide coordenates of the tile. While Z provides the distance to the center of the tile
+description: make some hexagonal tiles. XY provide coordinates of the tile. While Z provides the distance to the center of the tile
 use: <float4> hexTile(<float2> st)
 examples:
     - https://raw.githubusercontent.com/patriciogonzalezvivo/lygia_examples/main/draw_tiles.frag

--- a/space/parallaxMapping.glsl
+++ b/space/parallaxMapping.glsl
@@ -57,7 +57,7 @@ vec2 parallaxMapping_simple(in SAMPLER_TYPE tex, in vec3 V, in vec2 T, out float
     // calculate amount of offset for Parallax Mapping With Offset Limiting
     texCoordOffset = PARALLAXMAPPING_SCALE * V.xy * initialHeight;
 
-    // retunr modified texture coordinates
+    // return modified texture coordinates
     return T - texCoordOffset;
 }
 
@@ -147,7 +147,7 @@ vec2 parallaxMapping_relief(in SAMPLER_TYPE tex, in vec3 V, in vec2 T, out float
         // new depth from heightmap
         heightFromTexture = PARALLAXMAPPING_SAMPLER_FNC(tex, currentTextureCoords);
 
-        // shift along or agains vector V
+        // shift along or against vector V
         if(heightFromTexture > currentLayerHeight) // below the surface
         {
             currentTextureCoords -= deltaTexCoord;

--- a/space/parallaxMapping.hlsl
+++ b/space/parallaxMapping.hlsl
@@ -57,7 +57,7 @@ float2 parallaxMapping_simple(in SAMPLER_TYPE tex, in float3 V, in float2 T, out
     // calculate amount of offset for Parallax Mapping With Offset Limiting
     texCoordOffset = PARALLAXMAPPING_SCALE * V.xy * initialHeight;
 
-    // retunr modified texture coordinates
+    // return modified texture coordinates
     return T - texCoordOffset;
 }
 
@@ -147,7 +147,7 @@ float2 parallaxMapping_relief(in SAMPLER_TYPE tex, in float3 V, in float2 T, out
         // new depth from heightmap
         heightFromTexture = PARALLAXMAPPING_SAMPLER_FNC(tex, currentTextureCoords);
 
-        // shift along or agains vector V
+        // shift along or against vector V
         if(heightFromTexture > currentLayerHeight) // below the surface
         {
             currentTextureCoords -= deltaTexCoord;

--- a/space/parallaxMapping.msl
+++ b/space/parallaxMapping.msl
@@ -57,7 +57,7 @@ float2 parallaxMapping_simple(SAMPLER_TYPE tex, float3 V, float2 T, out float pa
     // calculate amount of offset for Parallax Mapping With Offset Limiting
     texCoordOffset = PARALLAXMAPPING_SCALE * V.xy * initialHeight;
 
-    // retunr modified texture coordinates
+    // return modified texture coordinates
     return T - texCoordOffset;
 }
 
@@ -147,7 +147,7 @@ float2 parallaxMapping_relief(SAMPLER_TYPE tex, float3 V, float2 T, out float pa
         // new depth from heightmap
         heightFromTexture = PARALLAXMAPPING_SAMPLER_FNC(tex, currentTextureCoords);
 
-        // shift along or agains vector V
+        // shift along or against vector V
         if(heightFromTexture > currentLayerHeight) // below the surface
         {
             currentTextureCoords -= deltaTexCoord;

--- a/version.glsl
+++ b/version.glsl
@@ -5,8 +5,8 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
-#ifndef LYGIA_VERSION_MAYOR
-#define LYGIA_VERSION_MAYOR 1
+#ifndef LYGIA_VERSION_MAJOR
+#define LYGIA_VERSION_MAJOR 1
 #endif
 
 #ifndef LYGIA_VERSION_MINOR

--- a/version.hlsl
+++ b/version.hlsl
@@ -5,8 +5,8 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
-#ifndef LYGIA_VERSION_MAYOR
-#define LYGIA_VERSION_MAYOR 1
+#ifndef LYGIA_VERSION_MAJOR
+#define LYGIA_VERSION_MAJOR 1
 #endif
 
 #ifndef LYGIA_VERSION_MINOR

--- a/version.wgsl
+++ b/version.wgsl
@@ -5,6 +5,6 @@ license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
 */
-const LYGIA_VERSION_MAYOR: u32 = 1u;
+const LYGIA_VERSION_MAJOR: u32 = 1u;
 const LYGIA_VERSION_MINOR: u32 = 3u;
 const LYGIA_VERSION_PATCH: u32 = 0u;


### PR DESCRIPTION
Basically `codespell -q 3 -L pres,Cann,daa,inout,ist,lod` and a few more manual changes.

~~I didn't change the `..._AMPLITUD_...` (`AMPLITUDE`), `..._ABBERATION` (`ABERRATION`) and `..._MAYOR` (`MAJOR`) option names / macro definitions. Should I also change them?~~

Please let me know if I changed words wrongly in some context :)