### PR TITLE
Make MSL mod() implementation match GLSL

### DIFF
--- a/math/mod.msl
+++ b/math/mod.msl
@@ -1,7 +1,7 @@
 /*
-contributors: Patricio Gonzalez Vivo, Anton Marini
-description: mod polyfill
-use: <bool2|bool3|bool4> mod(<float2|float3|float4>, <float2|float3|float4>) 
+contributors: Patricio Gonzalez Vivo, Anton Marini, Mike Hays
+description: An implementation of mod that matches the GLSL mod. Note that MSL's fmod is different.
+use: <bool2|bool3|bool4> mod(<float2|float3|float4>, <float2|float3|float4>)
 license:
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Prosperity License - https://prosperitylicense.com/versions/3.0.0
     - Copyright (c) 2021 Patricio Gonzalez Vivo under Patron License - https://lygia.xyz/license
@@ -11,16 +11,16 @@ license:
 #define FNC_MOD
 
 // Scalar mod function (float)
-inline float mod(float x, float y) { return fmod(x, y); }
+inline float mod(float x, float y) { return x - y * floor(x / y); }
 
 // Vector mod functions (float2, float3, float4)
-inline float2 mod(float2 x, float2 y) { return fmod(x, y); }
-inline float3 mod(float3 x, float3 y) { return fmod(x, y); }
-inline float4 mod(float4 x, float4 y) { return fmod(x, y); }
+inline float2 mod(float2 x, float2 y) { return x - y * floor(x / y); }
+inline float3 mod(float3 x, float3 y) { return x - y * floor(x / y); }
+inline float4 mod(float4 x, float4 y) { return x - y * floor(x / y); }
 
 // Scalar mod function with scalar divisor (float2, float3, float4)
-inline float2 mod(float2 x, float y) { return fmod(x, float2(y)); }
-inline float3 mod(float3 x, float y) { return fmod(x, float3(y)); }
-inline float4 mod(float4 x, float y) { return fmod(x, float4(y)); }
+inline float2 mod(float2 x, float y) { return mod(x, float2(y)); }
+inline float3 mod(float3 x, float y) { return mod(x, float3(y)); }
+inline float4 mod(float4 x, float y) { return mod(x, float4(y)); }
 
 #endif


### PR DESCRIPTION
# Problem

`mod()` in Metal shaders is 0 for negative inputs because it's using `fmod()`.

# Solution

Implement using `floor()`, the same way it's implemented for HLSL.

# Testing

I created a simple fragment shader with the following code:

```c++
    float3 modColor = float3(mod(st.x, 1));
    float3 fmodColor = float3(fmod(st.x, 1));
    float3 color = mix(fmodColor, modColor, step(0, st.y));
    return float4(color, 1);
```

When centered at 0,0 and y in (-1,1), this generates:

<img width="887" alt="image" src="https://github.com/user-attachments/assets/11cf100e-a0f0-4da3-b5f7-4b02cfc582f0" />

Similar test for `float2` version:

<img width="888" alt="image" src="https://github.com/user-attachments/assets/6ef78db3-ef32-40c2-b3ed-06b0f210b6ce" />

