### PR TITLE
Add missing `mod()` imports for MSL files

### DIFF
--- a/draw/digits.msl
+++ b/draw/digits.msl
@@ -1,3 +1,5 @@
+#include "../math/mod.msl"
+
 /*
 contributors: Patricio Gonzalez Vivo
 description: |

--- a/generative/srandom.msl
+++ b/generative/srandom.msl
@@ -1,3 +1,5 @@
+#include "../math/mod.msl"
+
 /*
 contributors: Patricio Gonzalez Vivo
 description: Signed Random

--- a/math/atan2.msl
+++ b/math/atan2.msl
@@ -1,4 +1,5 @@
 #include "const.msl"
+#include "mod.msl"
 
 /*
 contributors: Alexander Griffis

--- a/math/mirror.msl
+++ b/math/mirror.msl
@@ -1,3 +1,5 @@
+#include "mod.msl"
+
 /*
 contributors: Ian Heisters
 description: Transforms the input signal into a triangle wave. For instance, if x goes between 0 and 2, the returned value will go from 0 to 1, and then 1 to 0 a triangle shape.

--- a/math/mod2.msl
+++ b/math/mod2.msl
@@ -1,3 +1,5 @@
+#include "mod.msl"
+
 /*
 contributors: Mercury
 description: |

--- a/sdf/opRepeat.msl
+++ b/sdf/opRepeat.msl
@@ -1,3 +1,5 @@
+#include "../math/mod.msl"
+
 /*
 contributors:  Inigo Quiles
 description: repeat operation for 2D/3D SDFs 

--- a/space/bracketing.msl
+++ b/space/bracketing.msl
@@ -1,4 +1,5 @@
 #include "../math/const.msl"
+#include "../math/mod.msl"
 
 /*
 contributors: Huw Bowles ( @hdb1 )

--- a/space/brickTile.msl
+++ b/space/brickTile.msl
@@ -1,3 +1,4 @@
+#include "../math/mod.msl"
 #include "sqTile.msl"
 
 /*

--- a/space/checkerTile.msl
+++ b/space/checkerTile.msl
@@ -1,3 +1,4 @@
+#include "../math/mod.msl"
 #include "sqTile.msl"
 
 /*

--- a/space/windmillTile.msl
+++ b/space/windmillTile.msl
@@ -1,4 +1,5 @@
 #include "../math/const.msl"
+#include "../math/mod.msl"
 #include "rotate.msl"
 #include "sqTile.msl"
 


### PR DESCRIPTION
# Problem

Some files that use the `mod()` function didn't `#include` it

# Solution

Add the imports!

# Testing

Imported each file on its own and built. Note that the build did not succeed for `bracketing.msl`, but that's due to other errors, which should be fixed in #253 .