### PR TITLE
Fix compile errors in bracketing.msl and psrdnoise.msl

### DIFF
--- a/generative/psrdnoise.msl
+++ b/generative/psrdnoise.msl
@@ -30,7 +30,7 @@ license: |
 #ifndef FNC_PSRFNOISE
 #define FNC_PSRFNOISE
 
-float psrdnoise(float2 x, float2 period, float alpha, out float2 gradient) {
+float psrdnoise(float2 x, float2 period, float alpha, thread float2 &gradient) {
 
     // Transform to simplex space (axis-aligned hexagonal grid)
     float2 uv = float2(x.x + x.y*0.5, x.y);
@@ -116,7 +116,7 @@ float psrdnoise(float2 x, float2 period, float alpha, out float2 gradient) {
 	return 10.9 * n;
 }
 
-float psrdnoise(float2 x, float2 period, float alpha, out float2 gradient, out float3 dg) {
+float psrdnoise(float2 x, float2 period, float alpha, thread float2 &gradient, thread float3 &dg) {
 
 	// Transform to simplex space (axis-aligned hexagonal grid)
 	float2 uv = float2(x.x + x.y*0.5, x.y);
@@ -226,7 +226,7 @@ float psrdnoise(float2 x) {
     return psrdnoise(x, float2(0.0));
 }
 
-float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient) {
+float psrdnoise(float3 x, float3 period, float alpha, thread float3 &gradient) {
 
 #ifndef PSRDNOISE_PERLIN_GRID
     // Transformation matrices for the axis-aligned simplex grid
@@ -426,7 +426,7 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient) {
     return 39.5 * n; 
 }
 
-float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient, out float3 dg, out float3 dg2) {
+float psrdnoise(float3 x, float3 period, float alpha, thread float3 &gradient, thread float3 &dg, thread float3 &dg2) {
 
 #ifndef PSRDNOISE_PERLIN_GRID
     // Transformation matrices for the axis-aligned simplex grid

--- a/space/bracketing.msl
+++ b/space/bracketing.msl
@@ -24,9 +24,9 @@ license: MIT license (MIT) Copyright Huw Bowles May 2022
 // of directly taking the vector directly, take two samples of the texture
 // using coordinate frames at snapped angles, and then blend them based on
 // the angle of the original vector.
-void bracketing(float2 dir, out float2 vAxis0, out float2 vAxis1, out float blendAlpha) {
+void bracketing(float2 dir, thread float2 &vAxis0, thread float2 &vAxis1, thread float &blendAlpha) {
     // Heading angle of the original vector field direction
-    float angle = atan(dir.y, dir.x) + TWO_PI;
+    float angle = atan2(dir.y, dir.x) + TWO_PI;
 
     float AngleDelta = BRACKETING_ANGLE_DELTA;
 
@@ -39,9 +39,9 @@ void bracketing(float2 dir, out float2 vAxis0, out float2 vAxis1, out float blen
     vAxis0 = float2(cos(angle0), sin(angle0));
 
     // Compute the next V axis by rotating by the snap angle size
-    mat2 RotateByAngleDelta = mat2( cos(AngleDelta), sin(AngleDelta), 
-                                    -sin(AngleDelta), cos(AngleDelta));
-                                    
+    float2x2 RotateByAngleDelta = float2x2( cos(AngleDelta), sin(AngleDelta),
+                                            -sin(AngleDelta), cos(AngleDelta));
+
     vAxis1 = RotateByAngleDelta * vAxis0;
 
     // Blend to get final result, based on how close the vector was to the first snapped angle


### PR DESCRIPTION
Fixes https://github.com/patriciogonzalezvivo/lygia/issues/252

## Testing

I tested `psrdnoise()` with the following shader using the gradient output:

```c++
    float3 color;
    psrdnoise(float3(st * 4, time), 0, 0.1, color) * 0.5 + 0.5;
    return float4(color, 1);
```

<img width="887" alt="image" src="https://github.com/user-attachments/assets/8bf4619c-6451-40cc-aee3-3df64deeb71e" />

I don't have a great test case for `bracketing()`.