### PR TITLE
Fixed incorrect imports from copy-paste errors.

### DIFF
--- a/color/hueShift.wgsl
+++ b/color/hueShift.wgsl
@@ -1,5 +1,5 @@
-#include "space/hsl2rgb.glsl"
-#include "space/rgb2hsl.glsl"
+#include "space/hsl2rgb.wgsl"
+#include "space/rgb2hsl.wgsl"
 
 /*
 contributors:

--- a/color/space/srgb2lab.wgsl
+++ b/color/space/srgb2lab.wgsl
@@ -1,5 +1,5 @@
-#include "rgb2lab.glsl"
-#include "srgb2rgb.glsl"
+#include "rgb2lab.wgsl"
+#include "srgb2rgb.wgsl"
 
 /*
 contributors: Patricio Gonzalez Vivo

--- a/generative/pnoise.wgsl
+++ b/generative/pnoise.wgsl
@@ -1,7 +1,7 @@
-#include "../math/mod289.hlsl"
-#include "../math/permute.hlsl"
-#include "../math/taylorInvSqrt.hlsl"
-#include "../math/quintic.hlsl"
+#include "../math/mod289.wgsl"
+#include "../math/permute.wgsl"
+#include "../math/taylorInvSqrt.wgsl"
+#include "../math/quintic.wgsl"
 
 /*
 contributors: [Stefan Gustavson, Ian McEwan]

--- a/lighting/fresnel.wgsl
+++ b/lighting/fresnel.wgsl
@@ -1,4 +1,4 @@
-#include "common/schlick.glsl"
+#include "common/schlick.wgsl"
 
 /*
 contributors: Patricio Gonzalez Vivo

--- a/space/rotate.wgsl
+++ b/space/rotate.wgsl
@@ -1,4 +1,4 @@
-#include "../math/rotate2d.glsl"
+#include "../math/rotate2d.wgsl"
 
 /*
 contributors: Patricio Gonzalez Vivo


### PR DESCRIPTION
It appears that a numbr of WGSL modules have incorrect `#include` statements pointing to either HLSL or GLSL files.
Fixed the include directives to point to the correct language files.