### PR TITLE
Fix truncation issues in psrdnoise()

### DIFF
--- a/generative/psrdnoise.glsl
+++ b/generative/psrdnoise.glsl
@@ -327,6 +327,12 @@ float psrdnoise(vec3 x, vec3 period, float alpha, out vec3 gradient) {
         i3 = floor(i3 + 0.5);
     }
 
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
+
     // Compute one pseudo-random hash value for each corner
     vec4 hash = permute( permute( permute( 
                 vec4(i0.z, i1.z, i2.z, i3.z ))
@@ -523,6 +529,12 @@ float psrdnoise(vec3 x, vec3 period, float alpha, out vec3 gradient, out vec3 dg
         i2 = floor(i2 + 0.5);
         i3 = floor(i3 + 0.5);
     }
+
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
 
     // Compute one pseudo-random hash value for each corner
     vec4 hash = permute( permute( permute( 

--- a/generative/psrdnoise.hlsl
+++ b/generative/psrdnoise.hlsl
@@ -327,6 +327,12 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient) {
         i3 = floor(i3 + 0.5);
     }
 
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
+
     // Compute one pseudo-random hash value for each corner
     float4 hash = permute( permute( permute( 
                 float4(i0.z, i1.z, i2.z, i3.z ))
@@ -526,6 +532,12 @@ float psrdnoise(float3 x, float3 period, float alpha, out float3 gradient, out f
         i2 = floor(i2 + 0.5);
         i3 = floor(i3 + 0.5);
     }
+
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
 
     // Compute one pseudo-random hash value for each corner
     float4 hash = permute( permute( permute( 

--- a/generative/psrdnoise.msl
+++ b/generative/psrdnoise.msl
@@ -329,6 +329,12 @@ float psrdnoise(float3 x, float3 period, float alpha, thread float3 &gradient) {
         i3 = floor(i3 + 0.5);
     }
 
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
+
     // Compute one pseudo-random hash value for each corner
     float4 hash = permute( permute( permute( 
                 float4(i0.z, i1.z, i2.z, i3.z ))
@@ -525,6 +531,12 @@ float psrdnoise(float3 x, float3 period, float alpha, thread float3 &gradient, t
         i2 = floor(i2 + 0.5);
         i3 = floor(i3 + 0.5);
     }
+
+    // Avoid truncation effects in permutation
+    i0 = mod289(i0);
+    i1 = mod289(i1);
+    i2 = mod289(i2);
+    i3 = mod289(i3);
 
     // Compute one pseudo-random hash value for each corner
     float4 hash = permute( permute( permute( 


### PR DESCRIPTION
Fixes https://github.com/patriciogonzalezvivo/lygia/issues/288.

I tested the Metal and GLSL implementations with large values. I don't have an easy way to test HLSL. There is no WGSL implementation yet.