### PR TITLE
ci validation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+    branches: [tomain, lee/ci, patricio/ci]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    strategy:
+      matrix:
+       os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.26.0'
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Run CI checks (macOS)
+        if: matrix.os == 'macos-latest'
+        run: pnpm ci:check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lygia",
-  "version": "1.3.5-rc.3",
+  "version": "1.3.5-rc.4",
   "description": "lygia, it's a granular and multi-language shader library designed for performance and flexibility",
   "main": "dist/umd/lygia.main.js",
   "unpkg": "dist/umd/lygia.main.js",
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "rm -rf dist/* && webpack",
     "build:wesl": "wesl-packager --multiBundle --outDir dist",
+    "ci:check": "pnpm test:once && pnpm test:built",
     "lint": "eslint --fix --ext .js .",
     "prepublishOnly": "pnpm test:built",
     "test": "pnpm vitest",


### PR DESCRIPTION
automatic github ci validation on all pull requests

runs the package.json script "ci:check" (on macos since it require a gpu). 

ci:check
  - runs the wesl tests in local dev mode 
  - builds the wesl npm package 
  - reruns the tests against the built package

The ci script also runs against the following branches: `patricio/ci`, `lee/ci`, and `tomain`.

Committers can manually trigger a CI run without submitting a PR by pushing or force pushing to their personal branch target. 