### PR TITLE
add wesl entry to languages dictionary

### DIFF
--- a/prune.py
+++ b/prune.py
@@ -19,6 +19,10 @@ languages = {
         'ext': 'wgsl',
         'frameworks': [ "WebGPU" ],
     },
+    'WESL': {
+        'ext': 'wesl',
+        'frameworks': ["WebGPU"]
+    },
     'CUDA': {
         'ext': 'cuh',
         'frameworks': [ "CUDA" ],


### PR DESCRIPTION
Addresses #296 

Adds entry for `.wesl` shaders to fix bug where `prune.py` script didn't remove `.wesl` shaders when being used with the `--all` flag