### PR TITLE
mv image snapshots for testing to a separate repo, drop git-lfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __image_diffs__
 __image_actual__
 __image_diff_report__
 __image_dev__
+__image_snapshots__
 
 # let users experiment with AI, but don't clutter the repo
 .claude

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:deno:native": "deno run -A --unstable-webgpu npm:wgsl-test run",
     "test:native": "wgsl-test run",
     "test:native:built": "pnpm build:wesl && TEST_BUNDLES=true wgsl-test run",
-    "test:once": "pnpm vitest run && wgsl-test run"
+    "test:once": "pnpm vitest run && wgsl-test run",
+    "snapshot:push": "cd test/wesl/__image_snapshots__ && git add -A && git diff --cached --quiet || git commit -m 'update snapshots' && git push origin HEAD:main"
   },
   "repository": {
     "type": "git",

--- a/test/wesl/__image_snapshots__/.gitattributes
+++ b/test/wesl/__image_snapshots__/.gitattributes
@@ -1,1 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text

--- a/test/wesl/__image_snapshots__/brick-tile.png
+++ b/test/wesl/__image_snapshots__/brick-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b9429e6fae8bdf45b7bb193bb0fb90f8da480f5d73de1538ff434f5b8b53c5e
-size 1054

--- a/test/wesl/__image_snapshots__/checker-tile.png
+++ b/test/wesl/__image_snapshots__/checker-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f7fcd71094df13cffe9c9008437c367ba5294b1d59dbaaa0b1a2234b93b059f
-size 507

--- a/test/wesl/__image_snapshots__/dither-bayer3-gradient.png
+++ b/test/wesl/__image_snapshots__/dither-bayer3-gradient.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:918f475e9973043175ecb34263f3e030000e3de6826f6360b155f0e711d142d8
-size 19654

--- a/test/wesl/__image_snapshots__/dither-bluenoise3-gradient.png
+++ b/test/wesl/__image_snapshots__/dither-bluenoise3-gradient.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:348fa240c70d961ac2513bcce88f8955e444f9cd96de8af181db878399667d5b
-size 21756

--- a/test/wesl/__image_snapshots__/dither-vlachos3-gradient.png
+++ b/test/wesl/__image_snapshots__/dither-vlachos3-gradient.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4490ee9f57ada70f83027ab8e213755c9b48ac8c2b2142f7c1b5e8ceb28025c6
-size 27176

--- a/test/wesl/__image_snapshots__/draw-aa-glsl.png
+++ b/test/wesl/__image_snapshots__/draw-aa-glsl.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6087901288f9800c570f049b0cc9d94fec8a6694893f9be1432b92bd97085db2
-size 243206

--- a/test/wesl/__image_snapshots__/draw-aa.png
+++ b/test/wesl/__image_snapshots__/draw-aa.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a37f0977765bbd9b03f7a8174a84f39f0c8e8a7a2b363471a3a9920013ee37d4
-size 369168

--- a/test/wesl/__image_snapshots__/draw-shapes-glsl.png
+++ b/test/wesl/__image_snapshots__/draw-shapes-glsl.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aa3e7cc17095e118bd914257b02a4c386368e81b03ef4107ea61731e1080e114
-size 57753

--- a/test/wesl/__image_snapshots__/draw-shapes.png
+++ b/test/wesl/__image_snapshots__/draw-shapes.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26648ebebf5484b0d622e384d8662eb352961f4ab7a21106c755f707336249ba
-size 43688

--- a/test/wesl/__image_snapshots__/draw-stroke.png
+++ b/test/wesl/__image_snapshots__/draw-stroke.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8bb3a786f874ec473588f2defe474fb408c4b345897f20046f052e94fbc671b
-size 37495

--- a/test/wesl/__image_snapshots__/filter-edge-prewitt.png
+++ b/test/wesl/__image_snapshots__/filter-edge-prewitt.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52c85d1cf30ba8188d9d1c72917efa0d14f80bc8a1c9e01b6caaf367ab954b51
-size 191062

--- a/test/wesl/__image_snapshots__/filter-sharpen-adaptive.png
+++ b/test/wesl/__image_snapshots__/filter-sharpen-adaptive.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0de4e25504f4ea663e70e6469e1872a9bbbb266e4f0d563f8bebc81e2b83fe3
-size 161480

--- a/test/wesl/__image_snapshots__/filter-sharpen-adaptive4.png
+++ b/test/wesl/__image_snapshots__/filter-sharpen-adaptive4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0de4e25504f4ea663e70e6469e1872a9bbbb266e4f0d563f8bebc81e2b83fe3
-size 161480

--- a/test/wesl/__image_snapshots__/filter-sharpen-contrast-adaptive.png
+++ b/test/wesl/__image_snapshots__/filter-sharpen-contrast-adaptive.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cd34dccb67ea19426b877b7a2223014f0b6b07c4c666c5da4e8995655493b75
-size 175804

--- a/test/wesl/__image_snapshots__/filter-sharpen-fast.png
+++ b/test/wesl/__image_snapshots__/filter-sharpen-fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9a58e2313152177ad42f999f0e839e587e9d41a6c977e07fc772bd91ffa69e5
-size 194912

--- a/test/wesl/__image_snapshots__/filter-sharpen-fast4.png
+++ b/test/wesl/__image_snapshots__/filter-sharpen-fast4.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9a58e2313152177ad42f999f0e839e587e9d41a6c977e07fc772bd91ffa69e5
-size 194912

--- a/test/wesl/__image_snapshots__/hex-tile.png
+++ b/test/wesl/__image_snapshots__/hex-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b8c7eb8ecbeb02252b739f6a8ce22ceac5d64175b365bc305c5053d112b2379
-size 23294

--- a/test/wesl/__image_snapshots__/kaleidoscope.png
+++ b/test/wesl/__image_snapshots__/kaleidoscope.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d495df8879620ecf5ac369b792d7ad15cd7d62de7b7e1385a8cc82dc24b29b33
-size 47241

--- a/test/wesl/__image_snapshots__/layer-average.png
+++ b/test/wesl/__image_snapshots__/layer-average.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae58e2df3f0674fc101c8856ca653a8ee30315991a63c272bf1c68bc7e84bc5c
-size 10413

--- a/test/wesl/__image_snapshots__/layer-color.png
+++ b/test/wesl/__image_snapshots__/layer-color.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14da25c3fcdbe8052eaee6da5729ab1e194c37479d58fc82fa243296f6cbb27a
-size 434

--- a/test/wesl/__image_snapshots__/layer-colorburn.png
+++ b/test/wesl/__image_snapshots__/layer-colorburn.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:775dc16683346f31ed1e1f0f6c6abc024235472ee8208d115e8ce1217495005a
-size 9400

--- a/test/wesl/__image_snapshots__/layer-colordodge.png
+++ b/test/wesl/__image_snapshots__/layer-colordodge.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4d963076dce842862bb5a7c798a95b616f7153bd874fce6e3fac23ea103dc10
-size 9435

--- a/test/wesl/__image_snapshots__/layer-glow.png
+++ b/test/wesl/__image_snapshots__/layer-glow.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0cf4d9785cb04f29a3a4d43c4881f3cad9d8fc903008deac039f8ca5db9fb15
-size 10782

--- a/test/wesl/__image_snapshots__/layer-hardlight.png
+++ b/test/wesl/__image_snapshots__/layer-hardlight.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95675455577fc4a470069dd9e15f23bfce0c8d9449689aed9269b322dd66e029
-size 10651

--- a/test/wesl/__image_snapshots__/layer-hardmix.png
+++ b/test/wesl/__image_snapshots__/layer-hardmix.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f3440c5d5a9dfa7527f99c713c79298767abda95cddebbbb75984b6708387a7
-size 709

--- a/test/wesl/__image_snapshots__/layer-hue.png
+++ b/test/wesl/__image_snapshots__/layer-hue.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14da25c3fcdbe8052eaee6da5729ab1e194c37479d58fc82fa243296f6cbb27a
-size 434

--- a/test/wesl/__image_snapshots__/layer-linearburn.png
+++ b/test/wesl/__image_snapshots__/layer-linearburn.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:beb064f53123a38c02bd81897ba494c0ff9501510113227c6a169639639b2be9
-size 5473

--- a/test/wesl/__image_snapshots__/layer-lineardodge.png
+++ b/test/wesl/__image_snapshots__/layer-lineardodge.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:122f2a4084925e1808019836fd85757e574a7bf5917843e19bee02e3b7614159
-size 5563

--- a/test/wesl/__image_snapshots__/layer-linearlight.png
+++ b/test/wesl/__image_snapshots__/layer-linearlight.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fabaf8fee156ef930d731c85c20a5df68d23cbb4caa10dd02bd5ea0337f7e92
-size 5725

--- a/test/wesl/__image_snapshots__/layer-luminosity.png
+++ b/test/wesl/__image_snapshots__/layer-luminosity.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3c77e34a56bc6f840533634c63181197388e29b5f17209635053c97a7af69a
-size 452

--- a/test/wesl/__image_snapshots__/layer-negation.png
+++ b/test/wesl/__image_snapshots__/layer-negation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5016bbc1e758c7c9f9306f1d9f36ebc530ce3039cd04785632ca90d96845cd2
-size 13328

--- a/test/wesl/__image_snapshots__/layer-pinlight.png
+++ b/test/wesl/__image_snapshots__/layer-pinlight.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fe4d960e16d4e60d3eb5fa17b94a038d2e6570ef18bb8af401673fb372eabf2
-size 753

--- a/test/wesl/__image_snapshots__/layer-reflect.png
+++ b/test/wesl/__image_snapshots__/layer-reflect.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35ac2914ef9f8321ac8d2946dde66dd420d73dd003570c91f3642d53b4a2826f
-size 10325

--- a/test/wesl/__image_snapshots__/layer-saturation.png
+++ b/test/wesl/__image_snapshots__/layer-saturation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14da25c3fcdbe8052eaee6da5729ab1e194c37479d58fc82fa243296f6cbb27a
-size 434

--- a/test/wesl/__image_snapshots__/layer-softlight.png
+++ b/test/wesl/__image_snapshots__/layer-softlight.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96054d388173712714b688b51463ba914c95efa91496e7acfff8b9a58800c065
-size 8991

--- a/test/wesl/__image_snapshots__/layer-vividlight.png
+++ b/test/wesl/__image_snapshots__/layer-vividlight.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eb12d8c956c0cee369ebf1df3bde171de3721cc17114ab50326af2a1a7ef72f
-size 11655

--- a/test/wesl/__image_snapshots__/mirror-tile.png
+++ b/test/wesl/__image_snapshots__/mirror-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b153eadd9a4734e6a639868e35f940c05eb6888ee91873b7d5534c0cc904be4
-size 567

--- a/test/wesl/__image_snapshots__/perlin-noise-fbm.png
+++ b/test/wesl/__image_snapshots__/perlin-noise-fbm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a88765a3e4f663e26bd87c66f6be0a3ab313de2030fc4d84df16e51ddbe79f1f
-size 22265

--- a/test/wesl/__image_snapshots__/pnoise-tiling.png
+++ b/test/wesl/__image_snapshots__/pnoise-tiling.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:493151dd827597626eca208568bb974d7cb0c60ac305c624522d16e8db3a3d0b
-size 28267

--- a/test/wesl/__image_snapshots__/snoise-fbm.png
+++ b/test/wesl/__image_snapshots__/snoise-fbm.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1800b51dfb91cbd725a932312ed651318dd3d5515f35992c8b52abca2b73bb74
-size 36775

--- a/test/wesl/__image_snapshots__/sprite-megaman.png
+++ b/test/wesl/__image_snapshots__/sprite-megaman.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3239811bbac866fc56b6c2005663c4a079151441152efdf36c04e9fee62be024
-size 5931

--- a/test/wesl/__image_snapshots__/tri-tile.png
+++ b/test/wesl/__image_snapshots__/tri-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7644b5650c6296ff22a7fbbc3e3c84a1a287434d3301272a33bd90e521b70ff6
-size 23559

--- a/test/wesl/__image_snapshots__/wavelet-vorticity.png
+++ b/test/wesl/__image_snapshots__/wavelet-vorticity.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c2f9d93d358fd25d380a0658b443f19ede2a22375704a8a1c93051f800ce666
-size 35009

--- a/test/wesl/__image_snapshots__/windmill-tile.png
+++ b/test/wesl/__image_snapshots__/windmill-tile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4966b77a1499d5ed236dd28a721390af0a141204fc5f07697215e31932c038b2
-size 1594

--- a/test/wesl/__image_snapshots__/worley-cellular.png
+++ b/test/wesl/__image_snapshots__/worley-cellular.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3f5c2f8a12dd9856951233718f11c87e5dcc17adfd1e8a903cf6f41a0da576e
-size 34062

--- a/test/wesl/fetchSnapshots.ts
+++ b/test/wesl/fetchSnapshots.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const snapshotRepo =
+  "https://github.com/patriciogonzalezvivo/lygia-snapshots.git";
+const snapshotRevision = "3e5ed0a110c6c893735e290001bc11cdcef6a7c8";
+const snapshotDir = path.resolve(import.meta.dirname, "__image_snapshots__");
+
+/** vitest globalSetup: fetch snapshot images before tests run */
+export async function setup(): Promise<void> {
+  await fetchSnapshots(snapshotRepo, snapshotRevision, snapshotDir);
+}
+
+/** vitest globalTeardown: warn if snapshot images were modified */
+export async function teardown(): Promise<void> {
+  const result = spawnSync("git", ["status", "--porcelain"], {
+    cwd: snapshotDir,
+  });
+  const output = result.stdout?.toString().trim();
+  if (output) {
+    const lines = output.split("\n");
+    console.log(
+      `\n⚠ ${lines.length} snapshot image(s) changed. ` +
+        `Run \`pnpm snapshot:push\` to update the snapshots repo.\n`,
+    );
+  }
+}
+
+/** Clone or fetch+checkout a git repo to a local directory. */
+async function fetchSnapshots(
+  url: string,
+  revision: string,
+  targetDir: string,
+): Promise<void> {
+  if (await exists(targetDir)) {
+    // fetch only if the pinned revision isn't already in the local clone
+    if (!git(["cat-file", "-e", revision], targetDir)) {
+      git(["fetch", "--quiet", "origin"], targetDir, `Fetching ${url}`);
+    }
+    // checkout is local-only, no network call
+    git(
+      ["checkout", "--quiet", revision],
+      targetDir,
+      `Checking out ${revision}`,
+    );
+  } else {
+    // first run: shallow clone at the pinned revision
+    const parent = path.dirname(targetDir);
+    await fs.mkdir(parent, { recursive: true });
+    git(
+      ["clone", "--depth=1", "--revision", revision, url, targetDir],
+      parent,
+      `Cloning ${url} at ${revision}`,
+    );
+  }
+}
+
+function exists(p: string): Promise<boolean> {
+  return fs.access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+/** Run a git command synchronously. Throws with stderr on failure if msg is provided. */
+function git(args: string[], cwd: string, msg?: string): boolean {
+  const result = spawnSync("git", args, { cwd });
+  if (msg && result.status !== 0) {
+    throw new Error(`${msg} failed: ${result.stderr?.toString()}`);
+  }
+  return result.status === 0;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    reporters: ['default', 'vitest-image-snapshot/reporter']
+    reporters: ['default', 'vitest-image-snapshot/reporter'],
+    globalSetup: ['test/wesl/fetchSnapshots.ts'],
   },
 })


### PR DESCRIPTION
a script fetches the images from git if necesary before tests are run